### PR TITLE
Matl-db, update fig and citation refs in prelim exp. report

### DIFF
--- a/Documents/MaCFP2021_Part1_exp.bib
+++ b/Documents/MaCFP2021_Part1_exp.bib
@@ -1,0 +1,306 @@
+@article{astm1354standard,
+  title={Standard test method for heat and visible smoke release rates for materials and products using an oxygen consumption calorimeter},
+  author={ASTM, Standard},
+  journal={E1354-17},
+  year={2017},
+  publisher={American Society for Testing and Materials International}
+}
+
+@article{astm2058standard,
+  title={Standard Test Methods for Measurement of Material Flammability Using a Fire Propagation Apparatus (FPA)},
+  author={ASTM, Standard},
+  journal={E2058-2019},
+  year={2019},
+  publisher={American Society for Testing and Materials International}
+}
+
+
+@article{babrauskas1992cone,
+  title={A cone calorimeter for controlled-atmosphere studies},
+  author={Babrauskas, Vytenis and Twilley, William H and Janssens, Marc and Yusa, Shyuitsu},
+  journal={Fire and materials},
+  volume={16},
+  number={1},
+  pages={37--43},
+  year={1992},
+  publisher={Wiley Online Library}
+}
+
+@article{babrauskas1984development,
+  title={Development of the cone calorimeter—a bench-scale heat release rate apparatus based on oxygen consumption},
+  author={Babrauskas, Vytenis},
+  journal={Fire and Materials},
+  volume={8},
+  number={2},
+  pages={81--95},
+  year={1984},
+  publisher={Wiley Online Library}
+}
+
+@INCOLLECTION{SFPEHandbookCone,
+    AUTHOR="Babrauskas, V.",
+    TITLE="The cone calorimeter",
+    BOOKTITLE="SFPE Handbook of Fire Protection Engineering",
+    edition="5th",
+    PUBLISHER="Springer",
+    address="New York, NY",
+    YEAR="2016"
+	Chapter="28",
+    PAGES="952--980",
+}
+
+@unpublished{MaCFP_Guidelines_for_Part,
+	AUTHOR="{Batiot, B. Bruns, M., Hostikka, S., Leventon, I., Nakamura, Y., Reszka, P., Rogaume, T., Stoliarov, S.}", 
+	TITLE="{Guidelines for Participation in the 2021 Condensed Phase Workshop, version 1.2}",
+	HOWPUBLISHED="{Available online: http://iafss.org/macfp-condensed-phase-phenomena/}",
+	MONTH="May",
+	YEAR="2020"
+	}
+
+@article{brown2018proceedings,
+  title={Proceedings of the first workshop organized by the IAFSS Working Group on Measurement and Computation of Fire Phenomena (MaCFP)},
+  author={Brown, A and Bruns, M and Gollner, M and Hewson, J and Maragkos, Georgios and Marshall, A and McDermott, R and Merci, Bart and Rogaume, T and Stoliarov, S and others},
+  journal={Fire safety journal},
+  volume={101},
+  pages={1--17},
+  year={2018},
+  publisher={Elsevier}
+}
+
+
+@book{brown2001introduction,
+  title={Introduction to thermal analysis: techniques and applications},
+  author={Brown, Michael Ewart},
+  volume={1},
+  year={2001},
+  publisher={Springer Science \& Business Media}
+}
+
+
+@article{coats1963thermogravimetric,
+  title={Thermogravimetric analysis. A review},
+  author={Coats, AW and Redfern, JP},
+  journal={Analyst},
+  volume={88},
+  number={1053},
+  pages={906--924},
+  year={1963},
+  publisher={The Royal Society of Chemistry}
+}
+
+		
+		
+@article{consalvi2008numerical,
+  title={Numerical analysis of the heating process in upward flame spread over thick PMMA slabs},
+  author={Consalvi, Jean-Louis and Pizzo, Y and Porterie, Bernard},
+  journal={Fire Safety Journal},
+  volume={43},
+  number={5},
+  pages={351--362},
+  year={2008},
+  publisher={Elsevier}
+}
+
+@article{fiola2020comparison,
+  title={Comparison of Pyrolysis Properties of Extruded and Cast Poly (methyl methacrylate)},
+  author={Fiola, Gregory J and Chaudhari, Dushyant M and Stoliarov, Stanislav I},
+  journal={Fire Safety Journal},
+  pages={103083},
+  year={2020},
+  publisher={Elsevier}
+}
+
+@article{fukumoto2018large,
+  title={Large eddy simulation of upward flame spread on PMMA walls with a fully coupled fluid--solid approach},
+  author={Fukumoto, Kazui and Wang, Changjian and Wen, Jennifer},
+  journal={Combustion and flame},
+  volume={190},
+  pages={365--387},
+  year={2018},
+  publisher={Elsevier}
+}
+
+		
+@article{gustafsson1991transient,
+  title={Transient plane source techniques for thermal conductivity and thermal diffusivity measurements of solid materials},
+  author={Gustafsson, Silas E},
+  journal={Review of scientific instruments},
+  volume={62},
+  number={3},
+  pages={797--804},
+  year={1991},
+  publisher={American Institute of Physics}
+}
+
+
+@article{hirata1985thermal,
+  title={Thermal and oxidative degradation of poly (methyl methacrylate): weight loss},
+  author={Hirata, Toshimi and Kashiwagi, Takashi and Brown, James E},
+  journal={Macromolecules},
+  volume={18},
+  number={7},
+  pages={1410--1418},
+  year={1985},
+  publisher={ACS Publications}
+}
+
+
+@inproceedings{kashiwagi1982study,
+  title={A study of oxygen effects on nonflaming transient gasification of PMMA and PE during thermal irradiation},
+  author={Kashiwagi, Takashi and Ohlemiller, Thomas J},
+  booktitle={Symposium (International) on Combustion},
+  volume={19},
+  number={1},
+  pages={815--823},
+  year={1982},
+  organization={Elsevier}
+}
+
+
+@article{leventon2015flame,
+  title={A flame spread simulation based on a comprehensive solid pyrolysis model coupled with a detailed empirical flame structure representation},
+  author={Leventon, Isaac T and Li, Jing and Stoliarov, Stanislav I},
+  journal={Combustion and Flame},
+  volume={162},
+  number={10},
+  pages={3884--3895},
+  year={2015},
+  publisher={Elsevier}
+}
+
+
+@article{lyon2013principles,
+  title={Principles and practice of microscale combustion calorimetry},
+  author={Lyon, RE and Walters, RN and Stoliarov, SI and Safronava, N},
+  journal={Federal Aviation Administration: Atlantic City International Airport, NJ, USA},
+  year={2013}
+}
+
+@article{lyon2007criteria,
+  title={Criteria for piloted ignition of combustible solids},
+  author={Lyon, Richard E and Quintiere, James G},
+  journal={Combustion and Flame},
+  volume={151},
+  number={4},
+  pages={551--559},
+  year={2007},
+  publisher={Elsevier}
+}
+
+@article{matala2012generalized,
+  title={Generalized direct method for pyrolysis kinetic parameter estimation and comparison to existing methods},
+  author={Matala, Anna and Lautenberger, Chris and Hostikka, Simo},
+  journal={Journal of fire sciences},
+  volume={30},
+  number={4},
+  pages={339--356},
+  year={2012},
+  publisher={Sage Publications Sage UK: London, England}
+}
+
+@book{mcnaughton2003differential,
+  title={Differential scanning calorimetry},
+  author={McNaughton, JL and H{\"o}hne, G{\"u}nther and Hemminger, W and Flammersheim, H-J and Flammersheim, H-J},
+  year={2003},
+  publisher={Springer Science \& Business Media}
+}
+
+@manual{NeztschLFA,
+	title="{Light Flash Apparatus LFA 467 HyperFlash Series: Method, Technique, Applications of Thermal Diffusivity and Thermal Conductivity}",
+	organization="NETZSCH-Gerätebau GmbH",
+	address="Selb, Germany"
+}
+
+@article{nyazika2019pyrolysis,
+  title={Pyrolysis modeling, sensitivity analysis, and optimization techniques for combustible materials: A review},
+  author={Nyazika, Tatenda and Jimenez, Maude and Samyn, Fabienne and Bourbigot, Serge},
+  journal={Journal of fire sciences},
+  volume={37},
+  number={4-6},
+  pages={377--433},
+  year={2019},
+  publisher={SAGE Publications Sage UK: London, England}
+}
+
+@article{rhodes1996burning,
+  title={Burning rate and flame heat flux for PMMA in a cone calorimeter},
+  author={Rhodes, Brian T and Quintiere, James G},
+  journal={Fire Safety Journal},
+  volume={26},
+  number={3},
+  pages={221--240},
+  year={1996},
+  publisher={Elsevier}
+}
+
+@article{rogaume2019thermal,
+  title={Thermal decomposition and pyrolysis of solid fuels: Objectives, challenges and modelling},
+  author={Rogaume, Thomas},
+  journal={Fire Safety Journal},
+  volume={106},
+  pages={177--188},
+  year={2019},
+  publisher={Elsevier}
+}
+
+@article{stoliarov2016parameterization,
+  title={Parameterization and validation of pyrolysis models for polymeric materials},
+  author={Stoliarov, Stanislav I and Li, Jing},
+  journal={Fire Technology},
+  volume={52},
+  number={1},
+  pages={79--91},
+  year={2016},
+  publisher={Springer}
+}
+
+@article{swann2017controlled,
+  title={Controlled atmosphere pyrolysis apparatus II (CAPA II): A new tool for analysis of pyrolysis of charring and intumescent polymers},
+  author={Swann, Joshua D and Ding, Yan and McKinnon, Mark B and Stoliarov, Stanislav I},
+  journal={Fire Safety Journal},
+  volume={91},
+  pages={130--139},
+  year={2017},
+  publisher={Elsevier}
+}
+
+@article{taylor1994nist,
+  title={NIST Technical Note 1297: guidelines for evaluating and expressing the uncertainty of NIST measurement results},
+  author={Taylor, Barry N and Kuyatt, Chris E},
+  journal={National Institute for Standards and Technology},
+  year={1994}
+}
+
+@article{tewarson1992fire,
+  title={Fire behavior of polymethylmethacrylate},
+  author={Tewarson, A and Ogden, SD},
+  journal={Combustion and flame},
+  volume={89},
+  number={3-4},
+  pages={237--259},
+  year={1992},
+  publisher={Elsevier}
+}
+
+@article{vermina2019experimental,
+  title={Experimental assessment of bench-scale ignitability parameters},
+  author={Vermina Plathner, Frida and van Hees, Patrick},
+  journal={Fire and Materials},
+  volume={43},
+  number={2},
+  pages={123--130},
+  year={2019},
+  publisher={Wiley Online Library}
+}
+
+
+@INCOLLECTION{SFPEHandbookThermalDecomp,
+    AUTHOR="Witkowski, A., Stec, A., Hull, T.",
+    TITLE="Thermal Decomposition of Polymeric Materials",
+    BOOKTITLE="SFPE Handbook of Fire Protection Engineering",
+    edition="5th",
+    PUBLISHER="Springer",
+    address="New York, NY",
+    YEAR="2016"
+	Chapter="7",
+    PAGES="167--254",

--- a/Documents/MaCFP_2021_Report_Part_I_Experimental.tex
+++ b/Documents/MaCFP_2021_Report_Part_I_Experimental.tex
@@ -3,6 +3,9 @@
 \usepackage{times,mathptmx}
 \usepackage[pdftex]{graphicx}
 
+\usepackage{subcaption}
+\usepackage{graphicx}
+
 \usepackage{color}
 \usepackage{amsmath}
 \usepackage{multirow}
@@ -46,6 +49,12 @@ Submitted to the 2021 MaCFP Condensed Phase Workshop \\
 August 26, 2020 \\
 \end{center}
 
+\begin{figure}
+  \centering
+  \includegraphics[width=6in]{FIGURES/MaCFP_Logo}
+  \label{Cover_Image}
+\end{figure}
+
 \vfill
 
 \begin{flushright}
@@ -87,9 +96,9 @@ In April 2016, it was proposed that the MaCFP Working Group be expanded to inclu
  \item Quantifying the inter-laboratory variability for comparable experimental datasets; and
  \item Assessing the impact of the variability of model parameters on fire growth predictions
 \end{itemize}
-At the first MaCFP workshop, conducted in Lund, Sweden, at the 2017 IAFSS meeting [Brown et al., 2018], it was proposed that experimental data sets for pyrolysis model calibration and validation first be developed for relatively simple materials that are isotropic in nature and do not exhibit complex mechanical behavior such as melt flow, delamination or intumescence. Thus, cast black poly(methyl methacrylate), PMMA, was selected as a reference material for analysis. This material was selected because of its tendency to maintain its density while burning, insignificant melt flow, simple decomposition kinetics, and low transparency to infrared radiation. Samples of this PMMA were made available to participants and a reference document, ``Guidelines for Participation in the 2021 MaCFP Condensed Phase Workshop,'' was shared with the community to facilitate collaboration between participating institutions [Batiot et al., 2020].
+At the first MaCFP workshop, conducted in Lund, Sweden, at the 2017 IAFSS meeting \cite{brown2018proceedings}, it was proposed that experimental data sets for pyrolysis model calibration and validation first be developed for relatively simple materials that are isotropic in nature and do not exhibit complex mechanical behavior such as melt flow, delamination or intumescence. Thus, cast black poly(methyl methacrylate), PMMA, was selected as a reference material for analysis. This material was selected because of its tendency to maintain its density while burning, insignificant melt flow, simple decomposition kinetics, and low transparency to infrared radiation. Samples of this PMMA were made available to participants and a reference document, ``Guidelines for Participation in the 2021 MaCFP Condensed Phase Workshop,'' was shared with the community to facilitate collaboration between participating institutions \cite{MaCFP_Guidelines_for_Part}.
 
-Numerous review papers on pyrolysis model development and/or parameterization have recently been published [Nyazika et al., 2019; Rogaume, 2019; Stoliarov \& Li, 2016; Matala A., et al., 2012]. Although multiple experimental [Kashiwagi \& Ohlemiller, 1982; Hirata et al., 1985; Tewarson \& Ogden, 1992; Rhodes \& Quintiere, 1996] and computational modeling studies of the flammability response of PMMA exist in the literature [Consalvi et al. 2008, Leventon et al., 2015, Fukumoto et al., 2018] this effort represents the first coordinated attempt involving multiple institutions to simultaneously perform a series of pyrolysis experiments across a range of scales, characterize all relevant thermophysical properties of a fully specified material, and to compare the various methodologies for doing so.
+Numerous review papers on pyrolysis model development and/or parameterization have recently been published \cite{nyazika2019pyrolysis,rogaume2019thermal, stoliarov2016parameterization,matala2012generalized}. Although multiple experimental \cite{kashiwagi1982study, hirata1985thermal, tewarson1992fire, rhodes1996burning} and computational modeling studies of the flammability response of PMMA exist in the literature \cite{consalvi2008numerical, leventon2015flame, fukumoto2018large} this effort represents the first coordinated attempt involving multiple institutions to simultaneously perform a series of pyrolysis experiments across a range of scales, characterize all relevant thermophysical properties of a fully specified material, and to compare the various methodologies for doing so.
 
 \section{Material Selection}
 
@@ -97,13 +106,13 @@ The specific material of interest is a 6~mm (0.236~in) thick, black, cast PMMA m
 
 \section{Participating Laboratories}
 
-As of July 2020, sixteen institutions from ten different countries have submitted experimental measurements as part of the 2021 Condensed Phase MaCFP Workshop. These institutions and their countries are listed in Table~\ref{Table_1} and the location of each institution is shown in Fig.~\ref{Fig_1}. As this report is preliminary and further edits to experimental measurements may be required, in all figures and tables containing experimental measurements, institutions are referred to using a unique, anonymous city name. Participating labs should have received an email identifying their corresponding city names; please contact Isaac Leventon (isaac.leventon@nist.gov) if you have questions regarding this naming.
+As of July 2020, sixteen institutions from ten different countries have submitted experimental measurements as part of the 2021 Condensed Phase MaCFP Workshop. These institutions and their countries are listed in Table~\ref{Table_1} and the location of each institution is shown in Fig.~\ref{Fig:MaCFP_Map_20200831}. As this report is preliminary and further edits to experimental measurements may be required, in all figures and tables containing experimental measurements, institutions are referred to using a unique, anonymous city name. Participating labs should have received an email identifying their corresponding city names; please contact Isaac Leventon (isaac.leventon@nist.gov) if you have questions regarding this naming.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=6in]{SCRIPT_FIGURES/MaCFP_Map_20200831}
   \caption{Locations of Institutions that provided experimental measurements for the 2021 Condensed Phase MaCFP Workshop.}
-  \label{Fig_1}
+  \label{Fig:MaCFP_Map_20200831}
 \end{figure}
 
 \begin{table}
@@ -112,7 +121,7 @@ As of July 2020, sixteen institutions from ten different countries have submitte
 \begin{center}
 \begin{tabular}{|ll|}
 \hline
-Participating Institution                                           & City/State, Country \\ \hline \hline
+ \textbf{Participating Institution}                                 &  \textbf{City/State, Country} \\ \hline \hline
 Aalto University                                                    & Espoo, Finland \\ \hline
 Dansk Brand og Sikringsteknisk Institut (DBI)                       & Copenhagen, Denmark \\ \hline
 Lund University                                                     & Lund, Sweden \\ \hline
@@ -138,7 +147,7 @@ University of Queensland                                            & Queensland
 
 Experimental measurements were submitted electronically by participating institutions and were organized and made publicly available in the MaCFP repository, which is hosted on GitHub \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}. The repository was created and is managed by members of the MaCFP Organizing Committee. All measurement data submitted by each institution is organized in a single folder with the institution’s name. A consistent file naming convention is used for all test data (i.e., across all folders). File names indicate the institution name, experimental apparatus, and basic test conditions (e.g., incident heat flux or heating rate; gaseous environment). Measurement data from repeated experiments is saved in separate files, each numbered sequentially.
 
-Also included in each folder is a README.md file that provides a description of the test conditions of all experiments conducted and submitted. Participants were asked to provide a written description of test setup and procedure and to clearly define the conditions associated with the experiments conducted, as noted in Table~\ref{Table_2}.
+Also included in each folder is a README.md file that provides a description of the test conditions of all experiments conducted and submitted. Participants were asked to provide a written description of test setup and procedure and to clearly define the conditions associated with the experiments conducted, as noted in Table 2.
 
 \begin{table}[ht]
 \caption{Test conditions and output data requested from participants}
@@ -146,9 +155,9 @@ Also included in each folder is a README.md file that provides a description of 
 \begin{center}
 \begin{tabular}{ll}
 \multicolumn{2}{c}{Test Apparatus}                                                                       \\ \hline
-Thermogravimetric Analysis (TGA)                  & Differential Scanning Calorimetry (DSC)              \\
-Microscale Combustion Calorimetry (MCC)           & Cone Calorimeter                                     \\
-Fire Propagation Apparatus (FPA)                  & Controlled Atmosphere Pyrolysis Apparatus (CAPA)     \\
+ \textbf{Thermogravimetric Analysis (TGA)}         &  \textbf{Differential Scanning Calorimetry (DSC)}              \\
+ \textbf{Microscale Combustion Calorimetry (MCC)} &  \textbf{Cone Calorimeter}                                     \\
+ \textbf{Fire Propagation Apparatus (FPA)}                  &  \textbf{Controlled Atmosphere Pyrolysis Apparatus (CAPA)}     \\
 \multicolumn{2}{c}{Test Conditions}                                                                      \\ \hline
 Heating Rate [K/min]                              & Radiant heat flux (kW/m$^2$)                         \\
 Temperature Program:                              & Heater Temperature                                   \\
@@ -161,7 +170,7 @@ Calibration type, materials used, and frequency   &                             
 Carrier gas and associated flow rate              &                                                      \\
 Crucible type and volume                          &                                                      \\
 \multicolumn{2}{c}{Test Outputs}                                                                         \\ \hline
-Initial and Final Sample Mass [mg]                & Sample Surface Area [m2]                             \\
+Initial and Final Sample Mass [mg]                & Sample Surface Area [m$^2$]                             \\
 Time-resolved Sample Mass [mg]                    & Initial and Final Sample Mass [mg]                   \\
 Time-resolved Sample Temperature [K]              & Time-resolved Sample Mass [mg]                       \\
                                                   & Time-resolved Sample Back-Surface Temperature [K]    \\
@@ -177,7 +186,7 @@ No single approach for pyrolysis model parameterization was suggested by the org
 
 It was expected that participating institutions would submit data from experiments such as thermogravimetric analysis (TGA), differential scanning calorimetry (DSC), the Cone Calorimeter, slab gasification experiments, and the Fire Propagation Apparatus (FPA). Although participants could conduct any experiments that they deemed necessary to provide calibration data for pyrolysis model development, a key objective of this effort was to quantify the inter-laboratory variability for comparable experimental datasets. Thus, recommended test conditions (e.g., incident heat flux in cone calorimeter tests or heating rate in TGA tests) were defined for standard experiments so that, if participants conducted any of those tests as part of their pyrolysis model development, they could do so under similar conditions, thus allowing for direct comparison of results from different laboratories.
 
-In total, experiments were performed in eight unique apparatus under a combination of thirty-five different sets of test conditions (e.g., incident heat flux, heating rate, and/or gaseous environment). A brief description of each of the eight test apparatus used by participating institutions is provided in Sections~\ref{mg_tests} and \ref{g_tests} of this document. More information regarding these techniques is available in the literature [Brown, 2001, Witkowski et al. 2016]. Detailed descriptions of the specific test conditions used by participating labs are available on the MaCFP repository \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}.
+In total, experiments were performed in eight unique apparatus under a combination of thirty-five different sets of test conditions (e.g., incident heat flux, heating rate, and/or gaseous environment). A brief description of each of the eight test apparatus used by participating institutions is provided in Sections~\ref{mg_tests} and \ref{g_tests} of this document. More information regarding these techniques is available in the literature \cite{brown2001introduction,SFPEHandbookThermalDecomp}. Detailed descriptions of the specific test conditions used by participating labs are available on the MaCFP repository \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}.
 
 
 \section{Milligram-Scale Tests}
@@ -185,7 +194,7 @@ In total, experiments were performed in eight unique apparatus under a combinati
 
 \subsection{Thermogravimetric Analysis (TGA)}
 
-In TGA experiments, small samples (typically 3~mg to 10~mg) are heated at a constant rate ($5\le\beta\le20$~K/min) or maintained at constant elevated temperature in a carefully controlled gaseous environment (either inert or oxidative). Time-resolved measurements of sample mass and temperature are recorded. Care should be taken to ensure that crucibles and thermocouples selected for use in TGA tests are both compatible with the sample and test conditions of interest and that the instrument is calibrated for use under those specific tests conditions (i.e., atmosphere and heating rate). At the start of each day’s testing, a baseline correction should also be performed to account for artificial changes in measured sample mass due to changes in buoyancy during the heating program. Further detail regarding the principles and practices of TGA is available elsewhere [Coats \& Redfern, 1963].
+In TGA experiments, small samples (typically 3~mg to 10~mg) are heated at a constant rate ($5\le\beta\le20$~K/min) or maintained at constant elevated temperature in a carefully controlled gaseous environment (either inert or oxidative). Time-resolved measurements of sample mass and temperature are recorded. Care should be taken to ensure that crucibles and thermocouples selected for use in TGA tests are both compatible with the sample and test conditions of interest and that the instrument is calibrated for use under those specific tests conditions (i.e., atmosphere and heating rate). At the start of each day’s testing, a baseline correction should also be performed to account for artificial changes in measured sample mass due to changes in buoyancy during the heating program. Further detail regarding the principles and practices of TGA is available elsewhere \cite{coats1963thermogravimetric}.
 
 The combination of small sample size and relatively low heating rate used in TGA experiments allows for the assumption of infinitely fast transport processes, decoupling thermal degradation reactions from heat and mass transfer effects. Analysis of TGA mass and mass loss rate data thus allows for the study of condensed-phase thermal decomposition reaction mechanisms and the determination of the kinetics of these reactions.
 
@@ -237,7 +246,7 @@ Total         & 2 & 11  & 1 & 2 & 3 \\ \hline
 
 \subsection{Differential Scanning Calorimetry (DSC)}
 
-In DSC experiments, a small material sample is placed in a crucible of high thermal conductivity and heated alongside a reference crucible in a carefully controlled gaseous environment. Unlike TGA, sample mass is not recorded, but rather time-resolved measurements of sample temperature and heat flow. Heat flow to the sample can be measured in two ways: (1) power compensation DSC, in which the energy (supplied by electric current) needed to maintain the sample crucible at the same temperature as the reference crucible is directly measured, or (2) heat flux DSC, in which the temperature difference between the sample and reference pans is carefully measured during heating and prior calibration of the instrument allows for the determination of heat flux as a function of this temperature difference. Further detail regarding the principles and practices of differential scanning calorimetry is available elsewhere [McNaughton et al., 2003].
+In DSC experiments, a small material sample is placed in a crucible of high thermal conductivity and heated alongside a reference crucible in a carefully controlled gaseous environment. Unlike TGA, sample mass is not recorded, but rather time-resolved measurements of sample temperature and heat flow. Heat flow to the sample can be measured in two ways: (1) power compensation DSC, in which the energy (supplied by electric current) needed to maintain the sample crucible at the same temperature as the reference crucible is directly measured, or (2) heat flux DSC, in which the temperature difference between the sample and reference pans is carefully measured during heating and prior calibration of the instrument allows for the determination of heat flux as a function of this temperature difference. Further detail regarding the principles and practices of differential scanning calorimetry is available elsewhere \cite{mcnaughton2003differential}.
 
 DSC can be used to quantify the heat capacities of materials as well as heats of reaction of endo- or exothermic condensed-phase reactions and the temperatures at which they occur. These features of interest can be determined based on the deviations of measured heat flow to the sample versus from the baseline (heat flow to empty crucibles). In DSC tests, the baseline is not necessarily easy to establish. The baseline itself may deviate from zero for a variety of reasons including a mismatch of the thermal properties of the sample and the reference material, poor positioning of crucibles themselves or of the samples within their crucible, and/or asymmetry in the construction of sample and reference holders. Excellent thermal contact between the sample, the reference pans, and the instrument and careful calibration of the instrument for the exact test conditions used in each experiment is essential to obtaining accurate measurements of sample heat capacity or heats of decomposition.
 
@@ -269,7 +278,7 @@ $^*$Saint John submitted a single dataset, which represents average measurements
 
 \subsection{Microscale Combustion Calorimetry (MCC)}
 
-In MCC experiments, mg-scale samples are heated in a carefully controlled (typically anaerobic) gaseous environment, similar to TGA. Gaseous pyrolyzates produced by the sample are transported in an inert gas stream to a high-temperature furnace where they are mixed with excess oxygen and allowed to burn to completion. Measurement of total gas flow and oxygen concentration downstream of the furnace allows for calculation of sample heat release rate due to this non-flaming combustion, based on the principle of oxygen consumption calorimetry. The heat of complete combustion is obtained from the time integral of this heat release rate and measurements of initial and final sample mass. Further detail regarding the principles and practices of MCC is available elsewhere [Lyon et al., 2013].
+In MCC experiments, mg-scale samples are heated in a carefully controlled (typically anaerobic) gaseous environment, similar to TGA. Gaseous pyrolyzates produced by the sample are transported in an inert gas stream to a high-temperature furnace where they are mixed with excess oxygen and allowed to burn to completion. Measurement of total gas flow and oxygen concentration downstream of the furnace allows for calculation of sample heat release rate due to this non-flaming combustion, based on the principle of oxygen consumption calorimetry. The heat of complete combustion is obtained from the time integral of this heat release rate and measurements of initial and final sample mass. Further detail regarding the principles and practices of MCC is available elsewhere \cite{lyon2013principles}.
 
 Two institutions provided measurement data from repeated MCC tests conducted in a pure nitrogen environment. In each test, powdered samples between 4~mg and 7~mg were loaded into ceramic crucibles, weighed, and then introduced into the MCC pyrolyzer for 10~min at 348.15~K. Samples were then heated from ambient temperature through complete thermal decomposition at a constant heating rate of 60~K/min. Additional information, including  apparatus specifications, calibration details, and sample preparation, conditioning, and testing procedure, is provided in the README files for each experiment, which can be found in the MaCFP repository \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}.
 
@@ -278,9 +287,9 @@ Two institutions provided measurement data from repeated MCC tests conducted in 
 
 \subsection{Cone Calorimeter}
 
-In cone calorimetry experiments, gram-scale samples (typically 10~cm square, 6~mm thick) are placed on a layer of thermal insulation inside of a steel holder and exposed to a conical, radiant heater capable of providing an external heat flux of 10~kW/m$^2$ to 75~kW/m$^2$. Samples can be supported in either the horizontal or vertical configuration (typically horizontal) with or without a spark igniter. This provides nominally one-dimensional conduction where sample slabs can burn freely in well-ventilated, open-atmosphere conditions. Samples are supported above a load cell and positioned beneath a well-instrumented exhaust hood, capable of providing oxygen consumption measurements. Thus, the apparatus produces time-resolved measurements of sample mass loss and heat release rates. Further detail regarding the operating principles, best practices, complete capabilities, and analysis techniques of cone calorimetry is available elsewhere [Babrauskas, 1984, 2016; ASTM E1354-17].
+In cone calorimetry experiments, gram-scale samples (typically 10~cm square, 6~mm thick) are placed on a layer of thermal insulation inside of a steel holder and exposed to a conical, radiant heater capable of providing an external heat flux of 10~kW/m$^2$ to 75~kW/m$^2$. Samples can be supported in either the horizontal or vertical configuration (typically horizontal) with or without a spark igniter. This provides nominally one-dimensional conduction where sample slabs can burn freely in well-ventilated, open-atmosphere conditions. Samples are supported above a load cell and positioned beneath a well-instrumented exhaust hood, capable of providing oxygen consumption measurements. Thus, the apparatus produces time-resolved measurements of sample mass loss and heat release rates. Further detail regarding the operating principles, best practices, complete capabilities, and analysis techniques of cone calorimetry is available elsewhere \cite{babrauskas1984development, SFPEHandbookCone, astm1354standard}.
 
-Eleven labs submitted experimental measurements from 59 unique cone calorimeter tests conducted using an applied external heat flux of 25, 50, or 65~kW/m$^2$. For most of these tests, samples were 6~mm thick and 10~cm square. 'Blainville-Boisbriand' repeated experiments using smaller, circular samples, which has been reported to improve repeatability of experiments [Vermina Plathner \& Van Hees, 2019]. Tests were conducted both with and without frames (to keep samples in place within their holders) using a variety of backing insulation layers. Both of these features may impact the burning behavior of samples during experiments. Additional information, including apparatus specifications and calibration details, backing insulation thermal conductivity, and sample preparation, conditioning, and testing procedure, is provided in the README files for each experiment, which can be found in the MaCFP repository \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}. Table~\ref{Table_6} lists the number of cone calorimeter experiments conducted under each combination of test conditions.
+Eleven labs submitted experimental measurements from 59 unique cone calorimeter tests conducted using an applied external heat flux of 25, 50, or 65~kW/m$^2$. For most of these tests, samples were 6~mm thick and 10~cm square. 'Blainville-Boisbriand' repeated experiments using smaller, circular samples, which has been reported to improve repeatability of experiments \cite{vermina2019experimental}. Tests were conducted both with and without frames (to keep samples in place within their holders) using a variety of backing insulation layers. Both of these features may impact the burning behavior of samples during experiments. Additional information, including apparatus specifications and calibration details, backing insulation thermal conductivity, and sample preparation, conditioning, and testing procedure, is provided in the README files for each experiment, which can be found in the MaCFP repository \href{https://github.com/MaCFP/matl-db}{https://github.com/MaCFP/matl-db}. Table~\ref{Table_6} lists the number of cone calorimeter experiments conducted under each combination of test conditions.
 
 \begin{table}
 \caption{Test Matrix of Cone Calorimeter Experiments; table values indicate number of tests conducted under listed test conditions}
@@ -331,25 +340,25 @@ Total                    & 3  & 2  & 5  & 2  & 2  & 5  & 3  & 5                 
 
 \paragraph{Controlled Atmosphere Cone Calorimetry}
 
-In controlled atmosphere cone calorimetry, a standard cone calorimeter (described above) is modified by building an enclosure around the heater and the load cell. By supplying a well-defined mixture of nitrogen, oxygen, and/or air to this enclosure, a reduced oxygen environment can be maintained around the sample. Further information regarding the development of controlled atmosphere cone calorimetry and an explanation of how the controlled‐atmospheres unit is operated is provided elsewhere [Babrauskas et al., 1992].
+In controlled atmosphere cone calorimetry, a standard cone calorimeter (described above) is modified by building an enclosure around the heater and the load cell. By supplying a well-defined mixture of nitrogen, oxygen, and/or air to this enclosure, a reduced oxygen environment can be maintained around the sample. Further information regarding the development of controlled atmosphere cone calorimetry and an explanation of how the controlled‐atmospheres unit is operated is provided elsewhere \cite{babrauskas1992cone}.
 
 \paragraph{Controlled Atmosphere Pyrolysis Apparatus (CAPA)}
 
-The most recent version of this apparatus, CAPA~II, was used to obtain the reported data. CAPA~II provides a well-defined, axi-symmetric, one-dimensional heating environment in which a disc-shaped sample (7~cm diameter) is exposed to radiant heat supplied by the heating element of a cone calorimeter. The oxygen concentration around the sample can be reduced below 1~\% by supplying a co-flow of pure nitrogen around the sample. The sample rests on a painted copper foil exposed to the atmosphere to enable a non-intrusive back surface temperature measurement. In each experiment, time-resolved measurements of sample mass, back surface temperature, and sample profile evolution are recorded simultaneously. Additional information about CAPA~II, including quantification of boundary conditions, measurement capabilities and technique, and sample preparation, conditioning, and testing procedure, is available elsewhere [Swann et al., 2017].
+The most recent version of this apparatus, CAPA~II, was used to obtain the reported data. CAPA~II provides a well-defined, axi-symmetric, one-dimensional heating environment in which a disc-shaped sample (7~cm diameter) is exposed to radiant heat supplied by the heating element of a cone calorimeter. The oxygen concentration around the sample can be reduced below 1~\% by supplying a co-flow of pure nitrogen around the sample. The sample rests on a painted copper foil exposed to the atmosphere to enable a non-intrusive back surface temperature measurement. In each experiment, time-resolved measurements of sample mass, back surface temperature, and sample profile evolution are recorded simultaneously. Additional information about CAPA~II, including quantification of boundary conditions, measurement capabilities and technique, and sample preparation, conditioning, and testing procedure, is available elsewhere \cite{swann2017controlled}.
 
 \paragraph{Fire Propagation Apparatus (FPA)}
 
-In the FPA, for ignition, pyrolysis, and combustion tests (i.e., not for flame spread), horizontal samples (either 10~cm square or in diameter) are supported on a mass balance and exposed to external radiant heat from four quartz heaters typically operating at significantly higher temperatures than the heating element of the cone calorimeter. Samples are surrounded by a 17~cm diameter quartz tube, which allows for the co-flow of well-regulated mixtures of nitrogen and/or oxygen around the sample, thus allowing for the generation of an anerobic environment. Additional information about the FPA, including further discussion on its measurement capabilities, and sample preparation, conditioning, and testing procedure, is available elsewhere [ASTM 2058].
+In the FPA, for ignition, pyrolysis, and combustion tests (i.e., not for flame spread), horizontal samples (either 10~cm square or in diameter) are supported on a mass balance and exposed to external radiant heat from four quartz heaters typically operating at significantly higher temperatures than the heating element of the cone calorimeter. Samples are surrounded by a 17~cm diameter quartz tube, which allows for the co-flow of well-regulated mixtures of nitrogen and/or oxygen around the sample, thus allowing for the generation of an anerobic environment. Additional information about the FPA, including further discussion on its measurement capabilities, and sample preparation, conditioning, and testing procedure, is available elsewhere \cite{astm2058standard}.
 
 \subsection{Thermal Conductivity and Diffusivity}
 
-``Direct measurements'' of thermal conductivity and diffusivity were provided by one institution, using two separate apparatus: TPS hot disk [Gustafsson, 1991] and Laser Flash [Netzsch LFA 467]. The reader is referred to the technical reference guide and/or user’s manuals of each of these instruments for further information regarding their operating principles and related test procedures.
+``Direct measurements'' of thermal conductivity and diffusivity were provided by one institution, using two separate apparatus: TPS hot disk \cite{gustafsson1991transient} and Laser Flash \cite{NeztschLFA}. The reader is referred to the technical reference guide and/or user’s manuals of each of these instruments for further information regarding their operating principles and related test procedures.
 
 
 
 \chapter{Experimental Results}
 
-In this section, experimental measurements from both mg- and g-scale tests are presented. When tests were conducted under the same nominal experimental conditions (e.g., heating rate, incident heat flux, and/or gaseous environment) and when data provided by different institutions showed qualitative agreement, average curves (e.g., heat release or mass loss rate vs. time or temperature) and related uncertainties are calculated. Specifically, type A uncertainties[Taylor \& Kuyatt, 1994] are reported for all data as two standard deviations of the mean calculated over at least three independent observations, unless otherwise stated.
+In this section, experimental measurements from both mg- and g-scale tests are presented. When tests were conducted under the same nominal experimental conditions (e.g., heating rate, incident heat flux, and/or gaseous environment) and when data provided by different institutions showed qualitative agreement, average curves (e.g., heat release or mass loss rate vs. time or temperature) and related uncertainties are calculated. Specifically, type A uncertainties \cite{taylor1994nist} are reported for all data as two standard deviations of the mean calculated over at least three independent observations, unless otherwise stated.
 
 It should be noted that some variations between datasets are simply stochastic (i.e., random, unavoidable ‘noise’ in repeated tests); however, others may result from systematic causes (e.g., calibration differences in mg-scale experiments or sample holder and/or insulation type in g-scale experiments). Consequently, although clear outliers are not considered when calculating average curves (see further discussion throughout this section on how outliers are identified), care should be taken to understand if/how underlying differences in test conditions or procedure may have impacted the response of samples during experiments and thus how this may affect the final ‘average dataset’. Ultimately, average curves represent the aggregate of data as received, some of which may require corrections by the original submitting institution (e.g., if a dataset was incorrectly labeled or submitted).
 
@@ -361,22 +370,22 @@ The measurement data presented here is provided with limited processing and shou
 
 \paragraph{Heating Rate}
 
-All TGA experiments submitted to this workshop were performed at constant heating rates between 1 and 100 K/min. In practice, actual heating rate may vary throughout the course of experiments (especially at their start, while the TGA furnace is first heating up). Figures 2 and 3 show actual time-resolved heating rates in tests conducted, nominally, at $\beta$ = 10 and 20 K/min, respectively. In either figure, each curve represents the mean instantaneous heating rate as calculated from repeated experiments conducted by the same institution, under the same gaseous environment and target heating rate. When multiple curves are shown for the same institution on Fig. 2, they represent average heating rates measured in tests conducted under different gaseous environments (e.g., pure nitrogen, pure argon, or 10 to 21 vol. \% oxygen in nitrogen).
+All TGA experiments submitted to this workshop were performed at constant heating rates between 1 and 100 K/min. In practice, actual heating rate may vary throughout the course of experiments (especially at their start, while the TGA furnace is first heating up). Figures ~\ref{Fig:dTdt_TGA10K} and ~\ref{Fig:dTdt_TGA_20K} show actual time-resolved heating rates in tests conducted, nominally, at $\beta$ = 10 and 20 K/min, respectively. In either figure, each curve represents the mean instantaneous heating rate as calculated from repeated experiments conducted by the same institution, under the same gaseous environment and target heating rate. When multiple curves are shown for the same institution on Fig. ~\ref{Fig:dTdt_TGA10K}, they represent average heating rates measured in tests conducted under different gaseous environments (e.g., pure nitrogen, pure argon, or 10 to 21 vol. \% oxygen in nitrogen).
 
 As shown here, the actual heating rate can vary significantly during the early stages of testing (i.e., as samples are first heated from 50 to 150 K above their initial temperature) before $\beta$ finally reaches its target value. For experiments conducted by a single institution at the same nominal heating rate but under different gaseous environments, no systematic differences in time-resolved heating rates were observed.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/dTdt_TGA_10K}
   \caption{Average (of repeated experiments conducted by a single institution in the same gaseous environment) instantaneous heating rate during TGA experiments conducted at a nominal heating rate of $\beta=10$ K/min. Repeated curves for the same institution represent measurement data from tests conducted in different gaseous environments. Note: TGA tests submitted by ‘Gatineau’ at 10~K/min appear to have been conducted at 20~K/min.}
-  \label{Fig_2}
+  \label{Fig:dTdt_TGA_10K}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/dTdt_TGA_20K}
   \caption{Average (of repeated experiments conducted by a single institution) reported instantaneous heating rate during TGA experiments conducted at a nominal heating rate of $\beta=20$ K/min; all tests conducted in pure nitrogen.}
-  \label{Fig_3}
+  \label{Fig:dTdt_TGA_20K}
 \end{figure}
 
 
@@ -387,55 +396,102 @@ The key measurements recorded during TGA tests are sample mass, m [mg], and temp
 Tests were run at constant heating rates and both sample mass and temperature were reported at regular time or temperature intervals; effectively this meant that sample mass was reported, in most experiments, every ~0.5 K (the full range of reporting frequencies in datasets submitted by different institutions varied between 0.1 and 1 K per mass measurement, with two institutions submitting data with 5 or 6.7 K resolutions). Note: reporting frequency was not necessarily constant and, due to the nature of the experiment, measured sample temperature could actually decrease from one timestep to the next.
 
 For all tests, normalized mass, $m/m_0$, and time, t, signals were thus first processed (linear interpolation) such that they were each reported at the same regular intervals (i.e., every 0.5 K). For two experimental datasets (i.e., ‘Chicoutimi’ and ‘Rimouski’), the original reporting frequency of one or more of these signals was deemed too coarse (every 5 or 6.7 K) for this linear interpolation, thus this processing was not applied.
-Prior to further analysis, noise in all individual $m/m_0$ curves was reduced by applying a Savitzky-Golay filter (third order polynomial fit; 31 data point range). These fitting parameters were determined by trial and error, and future work will examine optimizing the choice of these parameters. Figure 4 shows the effect of this filter on a representative TGA dataset (data submitted by ‘Halifax’ from a test in pure nitrogen at 10 K/min).
+Prior to further analysis, noise in all individual $m/m_0$ curves was reduced by applying a Savitzky-Golay filter (third order polynomial fit; 31 data point range). These fitting parameters were determined by trial and error, and future work will examine optimizing the choice of these parameters. Figure ~\ref{Fig:TGA_N2_10K_1} shows the effect of this filter on a representative TGA dataset (data submitted by ‘Halifax’ from a test in pure nitrogen at 10 K/min).
 Normalized mass loss rate was then calculated at each temperature, $T_i$, as the numerical derivative of filtered sample mass curves across a 1 K interval, as per equation 1. In this way, the time step, $\Delta t$, needed for this calculation could vary (see previous discussion on heating rates) but it would always correspond to the time needed for sample mass to increase by 1~K).
 
 \begin{equation}
    \left.\ \frac{d\left(m/m_0\right)}{dt}\right|_{T=T_i}=\frac{1}{m_0}\frac{\left(m_{i-1}-m_{i+1}\right)}{\left(t_{i+1}-t_{i-1}\right)}
 \end{equation}
 
-Figure~\ref{Fig_4} shows the effect of applying this Savitzky-Golay filter to a particularly noisy set of TGA measurements. Here, filtered and unfiltered mass data is plotted (left axis; green and blue curves, respectively) along with filtered and unfiltered mass loss rate data (right axis; black and red curves, respectively). With this filter, random noise in the signal is cleanly removed but meaningful signal data remains (i.e., relevant mass loss events are not over-smoothed; no shift is observed in the onset or peak temperature of reactions, which could occur if a larger time interval, $\Delta t$, were used to smooth calculated mass loss rate; and peak mass loss rate is well captured). Given the effectiveness that this filter has demonstrated, it has been applied to all TGA measurements submitted to this workshop, prior to further analysis.
+Figure~\ref{Fig:TGA_N2_10K_1} shows the effect of applying this Savitzky-Golay filter to a particularly noisy set of TGA measurements. Here, filtered and unfiltered mass data is plotted (left axis; green and blue curves, respectively) along with filtered and unfiltered mass loss rate data (right axis; black and red curves, respectively). With this filter, random noise in the signal is cleanly removed but meaningful signal data remains (i.e., relevant mass loss events are not over-smoothed; no shift is observed in the onset or peak temperature of reactions, which could occur if a larger time interval, $\Delta t$, were used to smooth calculated mass loss rate; and peak mass loss rate is well captured). Given the effectiveness that this filter has demonstrated, it has been applied to all TGA measurements submitted to this workshop, prior to further analysis.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/TGA_N2_10K_1}
   \caption{Filtered and unfiltered mass data from a single TGA experiment conducted by ‘Halifax’ in pure nitrogen at 10 K/min as well as the resulting mass loss rate curves calculated from this mass data.}
-  \label{Fig_4}
+  \label{Fig:TGA_N2_10K_1}
 \end{figure}
 
-Figures 5-7 show measurement data from 4, 19, and 7 repeated tests conducted in pure nitrogen at nominal heating rates of $\beta$ = 5, 10 and 20 K/min, respectively. Note: Figure 6 also includes TGA measurements from ‘Moncton’, which conducted two anaerobic tests at 10 K/min in pure Argon. Figure 8 shows measurements from 11 repeated tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min.
+Figures ~\ref{Fig:TGA_N2_5K}-~\ref{Fig:TGA_N2_20K} show measurement data from 4, 19, and 7 repeated tests conducted in pure nitrogen at nominal heating rates of $\beta$ = 5, 10 and 20 K/min, respectively. Note: Figure ~\ref{Fig:TGA_N2_10K} also includes TGA measurements from ‘Moncton’, which conducted two anaerobic tests at 10 K/min in pure Argon. Figure ~\ref{Fig:TGA_O2-21_10K} shows measurements from 11 repeated tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min.
 
-Based on these measurements, average TGA curves and an estimate of measurement uncertainty were calculated for each of these conditions. An effort was made to include as much data as possible in the generation of these average curves; however, clear outliers (full curves, not just individual data points; i.e., all measurement data from an individual test) were not used for the calculation of mean and standard deviation values. These datasets are still plotted in Figs 5-8 with a note identifying them as outliers in the captions below their respective figures. For TGA measurements, datasets were defined as outliers, for example, when additional mass loss events were observed (‘Quebec’ tests in N$_2$ at 10 K/min), peak mass loss rates were $>50$~\% than the average of all other data, or a temperature shift of approximately 20~K or greater was observed in measurement results.
+Based on these measurements, average TGA curves and an estimate of measurement uncertainty were calculated for each of these conditions. An effort was made to include as much data as possible in the generation of these average curves; however, clear outliers (full curves, not just individual data points; i.e., all measurement data from an individual test) were not used for the calculation of mean and standard deviation values. These datasets are still plotted in Figs. ~\ref{Fig:TGA_N2_5K}-~\ref{Fig:TGA_O2-21_10K} with a note identifying them as outliers in the captions below their respective figures. For TGA measurements, datasets were defined as outliers, for example, when additional mass loss events were observed (‘Quebec’ tests in N$_2$ at 10 K/min), peak mass loss rates were $>50$~\% than the average of all other data, or a temperature shift of approximately 20~K or greater was observed in measurement results.
 
 For brevity, this document supplies figures of TGA measurement data only when repeated measurements under those test conditions were supplied by multiple labs. Normalized mass and mass loss rate curves (individual test data, along with average curves) from all TGA experiments conducted by all labs and under all experimental conditions (all heating rates and gaseous environments) are supplied in the Supplemental Information document.
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
-  \caption{Normalized mass and mass loss rate of TGA tests conducted in pure nitrogen at a nominal heating rate of $\beta=5$~K/min.}
-  \label{Fig_5}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_5KMass}
+   \caption{}
+   \label{Fig:TGA_N2_5KMass} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_5Kdmdt}
+   \caption{}
+   \label{Fig:TGA_N2_5Kdmdt} 
+\end{subfigure}
+  
+  \caption{Normalized (a) mass and (b) mass loss rate of TGA tests conducted in pure nitrogen at a nominal heating rate of $\beta=5$~K/min.}
+  \label{Fig:TGA_N2_5K}
 \end{figure}
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_10KMass}
+   \caption{}
+   \label{Fig:TGA_N2_10KMass} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_10Kdmdt}
+   \caption{}
+   \label{Fig:TGA_N2_10Kdmdt} 
+\end{subfigure}
+  
   \caption{Normalized mass and mass loss rate of TGA tests conducted in pure nitrogen (or pure argon, ‘Moncton’) at a nominal heating rate of $\beta = 10$ K/min. The following datasets are identified as outliers and will not be used for the calculation of mean and standard deviation values: Gatineau (clearly too high, likely conducted at 20~K/min; see Fig. 2); Quebec (two peaks); Rouyn-Noranda (~20~K shift in temperature).}
-  \label{Fig_6}
+  \label{Fig:TGA_N2_10K}
 \end{figure}
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_20KMass}
+   \caption{}
+   \label{Fig:TGA_N2_20KMass} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_N2_20Kdmdt}
+   \caption{}
+   \label{Fig:TGA_N2_20Kdmdt} 
+\end{subfigure}
+  
   \caption{Normalized mass and mass loss rate of TGA tests conducted in pure nitrogen at a nominal heating rate of $\beta=20$~K/min.}
-  \label{Fig_7}
+  \label{Fig:TGA_N2_20K}
 \end{figure}
 
+
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_O2-21_10KMass}
+   \caption{}
+   \label{Fig:TGA_O2-21_10KMass} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_O2-21_10Kdmdt}
+   \caption{}
+   \label{Fig:TGA_O2-21_10Kdmdt} 
+\end{subfigure}
+  
   \caption{Normalized mass and mass loss rate of TGA tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min.}
-  \label{Fig_8}
+  \label{Fig:TGA_O2-21_10K}
 \end{figure}
+
+
 
 When repeated measurements were available (submitted by the same or different lab(s) and conducted under the same incident heating conditions and gaseous environment) average mass loss rate, $\left.\frac{d\left(m/m_0\right)}{dt}\right|_{mean}$, was calculated at each Temperature, $T_i$, as the average value reported from all repeated tests, j :
 \begin{equation}
@@ -449,21 +505,45 @@ Type A uncertainties are reported for all data as two standard deviations of the
 \end{equation}
 When $\left.\ \frac{d\left(m/m_0\right)}{dt}\right|_{mean}$ and $\sigma_{mean,\ \frac{d\left(m/m_0\right)}{dt}}$ were calculated based on data provided by the same lab (except for ‘Chicoutimi’ and ‘Rimouski’), ni =2 in equations 2 and 3, as it is assumed that variations in these repeated measurements should be minimal within a 2 K interval (these values are plotted in the Supplemental Information document). When $\left.\ \frac{d\left(m/m_0\right)}{dt}\right|_{mean}$ and $\sigma_{mean,\ \frac{d\left(m/m_0\right)}{dt}}$  were calculated for across all labs (or for ‘Chicoutimi’ and ‘Rimouski’, due to coarser data reporting frequency), ni=0 as greater variability is expected between these individual tests (or data was simply not reported at a high enough frequency to allow for such calculations).
 
-Figure 9 plots average mass and mass loss rate curves from anaerobic TGA tests conducted at 5, 10, and 20 K/min on a single set of axes. Figure 10 plots average mass and mass loss rate curves along with measurements from 11 individual tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min; this allows for a qualitative representation of the ‘fit’ of this average curve to repeated measurements submitted by various institutions. In each plot (Figs. 9 and 10) average mass and mass loss rate is plotted as a solid curve surrounded by a shaded area, which represents $2\sigma_{mean}$.
+Figure ~\ref{Fig:TGA-N2_5_10_20K} plots average mass and mass loss rate curves from anaerobic TGA tests conducted at 5, 10, and 20 K/min on a single set of axes. Figure ~\ref{Fig:TGA_O2-21_10K_w_avg} plots average mass and mass loss rate curves along with measurements from 11 individual tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min; this allows for a qualitative representation of the ‘fit’ of this average curve to repeated measurements submitted by various institutions. In each plot (Figs. ~\ref{Fig:TGA-N2_5_10_20K} and ~\ref{Fig:TGA_O2-21_10K_w_avg}) average mass and mass loss rate is plotted as a solid curve surrounded by a shaded area, which represents $2\sigma_{mean}$.
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA-N2_5_10_20K_Mass}
+   \caption{}
+   \label{Fig:TGA-N2_5_10_20K_Mass} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA-N2_5_10_20K_dmdt}
+   \caption{}
+   \label{Fig:TGA-N2_5_10_20K_dmdt} 
+\end{subfigure}
+  
   \caption{Average normalized mass and mass loss rate of TGA tests conducted in pure nitrogen at $\beta$ = 5, 10, and 20 K/min. Average curves are calculated using all submitted data from tests conducted under the same conditions, excluding outliers, as noted above; shaded areas represent $2\sigma_{mean}$. Note: the average measurements plotted at 10~K/min include data from two anaerobic tests conducted at 10~K/min in pure Argon.}
-  \label{Fig_9}
+  \label{Fig:TGA-N2_5_10_20K}
 \end{figure}
 
+
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_O2-21_10KMass_w_avg}
+   \caption{}
+   \label{Fig:TGA_O2-21_10KMass_w_avg} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/TGA_O2-21_10Kdmdt_w_avg}
+   \caption{}
+   \label{Fig:TGA_O2-21_10Kdmdt_w_avg} 
+\end{subfigure}  
+  
   \caption{Normalized mass and mass loss rate of TGA tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min; shaded grey areas represent $2\sigma_{mean}$.}
-  \label{Fig_10}
+  \label{Fig:TGA_O2-21_10K_w_avg}
 \end{figure}
+
 
 \subsubsection{Tabulated values of interest}
 
@@ -494,7 +574,7 @@ Sherbrooke              & -           & -               & 2.8E-03        & 3.0E-
 \end{center}
 $^A$Calculated based on two values \\
 $^B$Standard deviation not calculated, only one experimental dataset provided \\
-$^C$Suspected error in submitted dataset, see figures \\
+$^C$Suspected error in submitted dataset, see mass loss rate in figures above\\
 $^D$Moncton experiments were conducted in Argon
 \end{table}
 
@@ -555,7 +635,7 @@ Sherbrooke              & -           & -               & 578            & 0    
 $^A$Calculated based on two values \\
 $^B$Standard deviation not calculated, only one experimental dataset provided \\
 $^C$Suspected error in submitted dataset, see figures \\
-$^D$Moncton experiments were conducted in Argon
+$^D$'Moncton' experiments were conducted in Argon
 \end{table}
 
 
@@ -570,21 +650,46 @@ For all tests, heat flow to the sample, q [W/g], and time, t [s], signals were t
 \begin{equation}
 Q_i=\sum_{T(t_0)}^{T_i}{\frac{1}{2}\left(q_{T_i}+q_{T_{i-1}}\right)\times\left(t_{T_i}-t_{T_{i-1}}\right)}
 \end{equation}
-Figures 11 and 12 show measurement data from 8 repeated tests conducted pure nitrogen or in oxygen and nitrogen ($X_{\rm O_2}=0.21$), respectively, at a nominal heating rate of $\beta=10$ K/min. Instantaneous and integral heat flow curves from DSC experiments conducted by all labs and under all experimental conditions (all heating rates and gaseous environments) are supplied in the Supplemental Information document.
+Figures ~\ref{Fig:DSC_N2_10K} and ~\ref{Fig:DSC_O2-21_10K} show measurement data from 8 repeated tests conducted pure nitrogen or in oxygen and nitrogen ($X_{\rm O_2}=0.21$), respectively, at a nominal heating rate of $\beta=10$ K/min. Instantaneous and integral heat flow curves from DSC experiments conducted by all labs and under all experimental conditions (all heating rates and gaseous environments) are supplied in the Supplemental Information document.
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/DSC_N2_10K_heatflow}
+   \caption{}
+   \label{Fig:DSC_N2_10K_heatflow} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/DSC_N2_10K_int_heatflow}
+   \caption{}
+   \label{Fig:DSC_N2_10K_int_heatflow} 
+\end{subfigure}
+  
   \caption{Heat flow and integral heat flow data from DSC tests conducted in pure nitrogen at a nominal heating rate of $\beta=10$ K/min. Note: data provided by Saint-John was submitted as an average measurement of 7 repeated tests. Uncertainty values in these measurements – which are plotted in the top image as shaded error bars and represent two standard deviations of the mean – were provided by ‘Saint John’.}
-  \label{Fig_11}
+  \label{Fig:DSC_N2_10K}
 \end{figure}
 
+
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/DSC_O2-21_10K_heatflow}
+   \caption{}
+   \label{Fig:DSC_O2-21_10K_heatflow} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/DSC_O2-21_10K_int_heatflow}
+   \caption{}
+   \label{Fig:DSC_O2-21_10K_int_heatflow} 
+\end{subfigure} 
+  
   \caption{Heat flow and integral heat flow data from DSC tests conducted in oxygen and nitrogen ($X_{\rm O_2}=0.21$) at a nominal heating rate of $\beta=10$~K/min.}
-  \label{Fig_12}
+  \label{Fig:DSC_O2-21_10K}
 \end{figure}
+
+
 
 Due to significant deviations  in heat flow measurements provided by each lab for tests conducted under the same set of heating and gaseous environment conditions, average DSC curves were not calculated based on measurements submitted by different institutions. However, when repeated measurements were available (submitted by the same institution and conducted under the same incident heating conditions and gaseous environment) average heat flow and integral heat flow (qmean and Qmean, respectively), were calculated at each Temperature, $T_i$, as the average value reported from all repeated tests, j  as per equation 5:
 \begin{equation}
@@ -599,7 +704,7 @@ Type A uncertainties are reported for averaged datasets as two standard deviatio
 Average instantaneous and integral heat flow curves from DSC experiments conducted by all labs and under all experimental conditions (all heating rates and gaseous environments) are supplied in the Supplemental Information document.
 
 
-As seen in Figs. 11 and 12, significant deviations exist between heat flow measurements provided by each lab; consequently, analysis of these measurements for the purposes of heat capacity or heat of reaction values may not be possible. However, when DSC measurements were obtained simultaneously with TGA data (in an STA test), an estimate of the heat of decomposition of PMMA can be calculated as follows. First, onset and endset temperatures of the primary mass loss reaction were defined (following the approach in Section 3.1.1) as the lowest and highest temperatures, respectively, at which normalized mass loss rate exceeded 10\% of $\left.\frac{d\left(m/m_0\right)}{dt}\right|_{max}$. Normalized sample mass loss due to decomposition across this temperature range was calculated as per equation. 7. On average, approximately 90\% of initial sample mass, m0, was lost as samples were heated through this temperature range.
+As seen in Figs. ~\ref{Fig:DSC_N2_10K} and ~\ref{Fig:DSC_O2-21_10K}, significant deviations exist between heat flow measurements provided by each lab; consequently, analysis of these measurements for the purposes of heat capacity or heat of reaction values may not be possible. However, when DSC measurements were obtained simultaneously with TGA data (in an STA test), an estimate of the heat of decomposition of PMMA can be calculated as follows. First, onset and endset temperatures of the primary mass loss reaction were defined (following the approach in Section 3.1.1) as the lowest and highest temperatures, respectively, at which normalized mass loss rate exceeded 10\% of $\left.\frac{d\left(m/m_0\right)}{dt}\right|_{max}$. Normalized sample mass loss due to decomposition across this temperature range was calculated as per equation. 7. On average, approximately 90\% of initial sample mass, m0, was lost as samples were heated through this temperature range.
 \begin{equation}
 \frac{\mathrm{\Delta m}}{m_0}=\frac{m_{onset}}{m_0}-\frac{m_{endset}}{m_0}
 \end{equation}
@@ -630,28 +735,39 @@ Quebec                & Nitrogen    & 10                   & 1142    & 970     &
 Chicoutimi            & Nitrogen    & 10                   & 695$^A$ & -       & -                      \\ \hline
 \end{tabular}
 \end{center}
-$^A$Saint John submitted a single dataset, which represents average measurements from 7 repeated tests
+$^A$'Saint John' submitted a single dataset, which represents average measurements from 7 repeated tests
 \end{table}
 
-DSC measurements were also conducted by one institution (‘Shawinigan’) with a custom heating program: in unique tests at three separate heating rates (3, 10, and 20 K/min) samples were repeatedly (3x) heated and cooled from 190 to 430 K in a pure nitrogen environment. Heat flow measurements from the heating phases of these experiments are provided in Figure 13. Following the recommendations of ‘Shawinigan’, who indicated that a heating of 30 to 50 K was needed to reach equilibrium, measurement data is only plotted between 240 K and 430 K.
+DSC measurements were also conducted by one institution (‘Shawinigan’) with a custom heating program: in unique tests at three separate heating rates (3, 10, and 20 K/min) samples were repeatedly (3x) heated and cooled from 190 to 430 K in a pure nitrogen environment. Heat flow measurements from the heating phases of these experiments are provided in Figure ~\ref{Fig:UMET_DSC_heatflow} . Following the recommendations of ‘Shawinigan’, who indicated that a heating of 30 to 50 K was needed to reach equilibrium, measurement data is only plotted between 240 K and 430 K.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/UMET_DSC_heatflow}
   \caption{Measured heat flow during DSC experiments conducted at low temperatures.}
-  \label{Fig_13}
+  \label{Fig:UMET_DSC_heatflow}
 \end{figure}
 
 
 \subsection{Microscale Combustion Calorimetry (MCC)}
 
-Two institutions conducted MCC experiments in Nitrogen at 60 K/min; this data is shown in Figure 14. ‘Halifax’ submitted data from only two experiments; ‘Saint John’ submitted a single dataset that represents the average of four repeated experiments.  Due to the limited availability of measurement data, statistics are therefore not calculated or presented for MCC tests. Uncertainty measurements plotted in Figure 14 were provided by ‘Saint John’; they represent two standard deviations of the mean [Fiola et al., submitted 2020]. Final, steady state values of integral HRR – effectively, the heat of combustion, $\Delta H_{\rm c}$ (which is equal to the total energy released per gram of gaseous volatiles produced [kJ/g], as char yield, $\mu_{\rm char}=0$) – averages 23.5 and 24.5 kJ/g for ‘Halifax’ and ‘Saint John’ measurements, respectively.
+Two institutions conducted MCC experiments in Nitrogen at 60 K/min; this data is shown in Figure ~\ref{Fig:MCC_N2_60K}. ‘Halifax’ submitted data from only two experiments; ‘Saint John’ submitted a single dataset that represents the average of four repeated experiments.  Due to the limited availability of measurement data, statistics are therefore not calculated or presented for MCC tests. Uncertainty measurements plotted in Figure ~\ref{Fig:MCC_N2_60K} were provided by ‘Saint John’; they represent two standard deviations of the mean \cite{fiola2020comparison}. Final, steady state values of integral HRR – effectively, the heat of combustion, $\Delta H_{\rm c}$ (which is equal to the total energy released per gram of gaseous volatiles produced [kJ/g], as char yield, $\mu_{\rm char}=0$) – averages 23.5 and 24.5 kJ/g for ‘Halifax’ and ‘Saint John’ measurements, respectively.
 
 \begin{figure}
-  \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+\centering
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/MCC_N2_60K_HRR}
+   \caption{}
+   \label{Fig:MCC_N2_60K_HRR} 
+\end{subfigure}
+
+\begin{subfigure}[b]{0.85\textwidth}
+   \includegraphics[width=1\linewidth]{SCRIPT_FIGURES/MCC_N2_60K_int_HRR}
+   \caption{}
+   \label{Fig:MCC_N2_60K_int_HRR} 
+\end{subfigure}
+  
   \caption{Measured HRR and integral HRR in MCC experiments conducted at 60 K/min. Data provided by Saint-John was submitted as an average measurement of 4 repeated tests.}
-  \label{Fig_14}
+  \label{Fig:MCC_N2_60K}
 \end{figure}
 
 
@@ -663,30 +779,30 @@ Key measurement data from cone calorimeter tests include: sample heat release ra
 
 \paragraph{Heat Release Rate}
 
-Ten labs submitted measurements from a total of 30 cone calorimeter tests conducted at 25 kW/m$^2$; between $1\le j\le6$ repeated experiments were submitted by each institution. Figure 15 plots measured HRR from tests submitted by each lab. As seen here, measurements submitted by ‘Drummondville’ (dark green markers), can be identified as clear outliers (factor of 2x too high). Further analysis to determine an average heat release rate ($HRR_{mean}$) and related $\sigma_{mean,\ HRR}$ for cone calorimeter tests conducted at 25 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. 15 except for that submitted by ‘Drummondville’. Data submitted by ‘Sherbrooke (light blue, delayed ignition) and Cape Breton (red, reduced HRR) measurements were still included in the calculation of  $HRR_{mean}$ and $\sigma_{mean,\ HRR}$.
+Ten labs submitted measurements from a total of 30 cone calorimeter tests conducted at 25 kW/m$^2$; between $1\le j\le6$ repeated experiments were submitted by each institution. Figure ~\ref{Fig:Cone_25kWindivHRR} plots measured HRR from tests submitted by each lab. As seen here, measurements submitted by ‘Drummondville’ (dark green markers), can be identified as clear outliers (factor of 2x too high). Further analysis to determine an average heat release rate ($HRR_{mean}$) and related $\sigma_{mean,\ HRR}$ for cone calorimeter tests conducted at 25 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. 15 except for that submitted by ‘Drummondville’. Data submitted by ‘Sherbrooke (light blue, delayed ignition) and Cape Breton (red, reduced HRR) measurements were still included in the calculation of  $HRR_{mean}$ and $\sigma_{mean,\ HRR}$.
 
-Only one institution, ‘Blainville-Boisbriand’, conducted experiments at 50 kW/m$^2$ (three repeated experiments). Heat release rate measurements from these tests are plotted in Figure 16.
-Ten labs submitted measurement data from a total of 27 Cone Calorimeter tests conducted at 65 kWm-2; between $1\le j\le4$ repeated experiments were submitted by each lab. Figure 17 plots measured HRR from each of these tests. As seen here, measurements submitted by ‘Drummondville’ (dark green markers), can be identified as clear outliers (factor of 2x too high); two experiments submitedby ‘Gatineau’ (dark blue markers) are also identified as outliers (factor of 2x too low). Further analysis to determine $HRR_{mean}$ and related $\sigma_{mean}$ for cone calorimeter tests conducted at 65 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. 15 except for these two datasets. Data submitted by ‘Sherbrooke (light blue, delayed rise in HRR) and Cape Breton (red, reduced HRR) measurements were still included in the calculation of  $HRR_{mean}$ and $\sigma_{mean,\ HRR}$.
+Only one institution, ‘Blainville-Boisbriand’, conducted experiments at 50 kW/m$^2$ (three repeated experiments). Heat release rate measurements from these tests are plotted in Figure ~\ref{Fig:Cone_50kWindivHRR}.
+Ten labs submitted measurement data from a total of 27 Cone Calorimeter tests conducted at 65 kWm-2; between $1\le j\le4$ repeated experiments were submitted by each lab. Figure ~\ref{Fig:Cone_65kWindivHRR} plots measured HRR from each of these tests. As seen here, measurements submitted by ‘Drummondville’ (dark green markers), can be identified as clear outliers (factor of 2x too high); two experiments submitedby ‘Gatineau’ (dark blue markers) are also identified as outliers (factor of 2x too low). Further analysis to determine $HRR_{mean}$ and related $\sigma_{mean}$ for cone calorimeter tests conducted at 65 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. ~\ref{Fig:Cone_65kWindivHRR} except for these two datasets. Data submitted by ‘Sherbrooke (light blue, delayed rise in HRR) and Cape Breton (red, reduced HRR) measurements were still included in the calculation of  $HRR_{mean}$ and $\sigma_{mean,\ HRR}$.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_25kWindivHRR_noavg}
   \caption{Measured heat release rate in cone calorimeter tests at 25 kW/m$^2$. Curves for each institution represent heat release rate measurements from individual experiments.}
-  \label{Fig_15}
+  \label{Fig:Cone_25kWindivHRR}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_50kWindivHRR_noavg}
   \caption{Measured heat release rate in cone calorimeter tests at 50 kW/m$^2$. All measurements submitted by ‘Blainville-Boisbriand’.}
-  \label{Fig_16}
+  \label{Fig:Cone_50kWindivHRR}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_65kWindivHRR_noavg}
   \caption{Measured heat release rate in cone calorimeter tests at 65 kW/m$^2$. Curves for each institution represent heat release rate measurements from individual experiments.}
-  \label{Fig_17}
+  \label{Fig:Cone_65kWindivHRR}
 \end{figure}
 
 When repeated measurements were available (submitted by the same or different lab(s) under the same incident heating conditions) average HRR ($HRR_{mean}$) was calculated at each timestep, $t_i$, as the average value reported from all repeated tests, j :
@@ -701,45 +817,45 @@ Type A uncertainties are reported for all data as two standard deviations of the
 When $HRR_{mean,i}$ and $\sigma_{mean,\ HRR}$ were calculated based on data provided by the same lab (except for ‘Gatineau’ and ‘Rimouski’ due to lower reporting frequencies), ni =2 in equations 10 and 11, as it is assumed that variations in these repeated measurements should be minimal within a +/- 2 s interval. When $HRR_{mean,i}$ and $\sigma_{mean,\ HRR}$ were calculated across all labs (or for ‘Gatineau’ and ‘Rimouski’, due to their coarser time resolution), ni=0 as greater variability is expected between these individual tests (or data was simply not reported at a high enough frequency to allow for such calculations).
 
 
-Figure 18 plots average HRR curves from cone calorimeter tests conducted at 25, 50, and 65 kW/m$^2$. Heat release rate measurements from cone calorimeter experiments conducted by all labs and under all external heating conditions (both individual measurements and average values, plotted with associated uncertainties) are supplied in the Supplemental Information document.
+Figure ~\ref{Fig:Cone-Calorimeter-all-fluxes} plots average HRR curves from cone calorimeter tests conducted at 25, 50, and 65 kW/m$^2$. Heat release rate measurements from cone calorimeter experiments conducted by all labs and under all external heating conditions (both individual measurements and average values, plotted with associated uncertainties) are supplied in the Supplemental Information document.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone-Calorimeter-all-fluxes}
   \caption{Comparison of average measured HRR in cone calorimeter tests at incident heat fluxes of q”ext = 25, 50, and 65 kW/m$^2$. Average curves are calculated using all submitted data from tests conducted under the same conditions, excluding outliers, as noted above; shaded areas represent $2\sigma_{mean}$.}
-  \label{Fig_18}
+  \label{Fig:Cone-Calorimeter-all-fluxes}
 \end{figure}
 
 
 \paragraph{Back Surface Temperature}
 
-If measured in cone calorimeter tests, back surface temperature, Tback, was recorded at up to three locations during each experiment. Eight labs submitted 30 temperature measurements from a total of 19 unique cone calorimeter tests conducted with an external heat flux of 25 kWm-2. Between $1\le j\le4$ repeated experiments were submitted by each institution.  Figure 19 plots back surface temperature measurements from tests submitted by each lab. As seen here, measurements submitted by ‘Cape-Breton’ (red markers) can be identified as clear outliers (too low). Additionally, 4 out of 6 ‘Chicoutimi’ measurements (yellow markers), are also noted as outliers: these temperatures were not measured directly at the back surface of samples. Further analysis to determine $T_{back,mean}$ and related $\sigma_{mean,\ T_{back}}$ for cone calorimeter tests conducted at 25 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. 19 except for these datasets.
+If measured in cone calorimeter tests, back surface temperature, Tback, was recorded at up to three locations during each experiment. Eight labs submitted 30 temperature measurements from a total of 19 unique cone calorimeter tests conducted with an external heat flux of 25 kWm-2. Between $1\le j\le4$ repeated experiments were submitted by each institution.  Figure ~\ref{Fig:Cone_25kWindivTEMP} plots back surface temperature measurements from tests submitted by each lab. As seen here, measurements submitted by ‘Cape-Breton’ (red markers) can be identified as clear outliers (too low). Additionally, 4 out of 6 ‘Chicoutimi’ measurements (yellow markers), are also noted as outliers: these temperatures were not measured directly at the back surface of samples. Further analysis to determine $T_{back,mean}$ and related $\sigma_{mean,\ T_{back}}$ for cone calorimeter tests conducted at 25 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. ~\ref{Fig:Cone_25kWindivTEMP} except for these datasets.
 
-Only one institution, ‘Blainville-Boisbriand’, conducted experiments at 50 kW/m$^2$. In one of these experiments, $T_{\rm back}$ was measured at one location; this data is plotted in Figure 20 and no further statistical analysis is performed.
+Only one institution, ‘Blainville-Boisbriand’, conducted experiments at 50 kW/m$^2$. In one of these experiments, $T_{\rm back}$ was measured at one location; this data is plotted in Fig. ~\ref{Fig:Cone_50kWindivTEMP} and no further statistical analysis is performed.
 
-Nine labs submitted 33 temperature measurements from a total of 17 unique cone calorimeter tests conducted at 65~kW/m$^2$. Between $1\le j\le4$ repeated experiments were submitted by each institution; up to 3 thermocouples were used in each test. Figure 21 plots back surface temperature measurements from tests submitted by each lab. Once again, measurements  submitted by ‘Cape-Breton’ (red markers) and 4 of 6 ‘Chicoutimi’ measruements (yellow markers) were identified as clear outliers. $T_{back,mean}$ and related $\sigma_{mean,\ T_{back}}$ for cone calorimeter tests conducted at 65 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. 21 except for these datasets.
+Nine labs submitted 33 temperature measurements from a total of 17 unique cone calorimeter tests conducted at 65~kW/m$^2$. Between $1\le j\le4$ repeated experiments were submitted by each institution; up to 3 thermocouples were used in each test. Figure ~\ref{Fig:Cone_65kWindivTEMP} plots back surface temperature measurements from tests submitted by each lab. Once again, measurements  submitted by ‘Cape-Breton’ (red markers) and 4 of 6 ‘Chicoutimi’ measruements (yellow markers) were identified as clear outliers. $T_{back,mean}$ and related $\sigma_{mean,\ T_{back}}$ for cone calorimeter tests conducted at 65 kW/m$^2$ was thus conducted based on all measurement data shown in Fig. ~\ref{Fig:Cone_65kWindivTEMP} except for these datasets.
 
 
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_25kWindivTEMP_noavg}
   \caption{Measured back surface temperature, Tback, in cone calorimeter tests conducted at 25 kW/m$^2$. Each curve (except for 4 of 6 ‘Chicoutimi datasets’) represents Tback measurements recorded by individual thermocouples in repeated experiments.}
-  \label{Fig_19}
+  \label{Fig:Cone_25kWindivTEMP}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_50kW_TEMP}
   \caption{Measured back surface temperature, Tback, from a cone calorimeter test conducted by ‘Blainville-Boisbriand’ at 50 kW/m$^2$.}
-  \label{Fig_20}
+  \label{Fig:Cone_50kWindivTEMP}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone_65kWindivTEMP_noavg}
   \caption{Measured back surface temperature, Tback, in cone calorimeter tests conducted at 65 kW/m$^2$. Each curve (except for 4 of 6 ‘Chicoutimi datasets’) represents Tback measurements recorded by individual thermocouples in repeated experiments.}
-  \label{Fig_21}
+  \label{Fig:Cone_65kWindivTEMP}
 \end{figure}
 
 
@@ -753,19 +869,19 @@ where N = number of individual data points across the interval $i-n_i\le i\le i+
 \end{equation}
 When $T_{back,\ mean_i}$ and $\sigma_{mean,\ {T_{back}}_i}$ were calculated based on data provided by the same lab, $ni =2$, as it is assumed that variations in these repeated measurements should be minimal within a +/- 2 s interval. When $T_{back,\ mean_i}$ and $\sigma_{mean,\ {T_{back}}_i}$ were calculated for across all labs, $ni=0$ as greater variability is expected between these individual tests.
 
-Figure~\ref{22} plots average Tback curves from cone calorimeter tests conducted at 25, 50, and 65 kW/m$^2$. Back surface temperature measurements from cone calorimeter experiments conducted by all labs and under all external heating conditions (both individual measurements and average values, plotted with associated uncertainties) are supplied in the Supplemental Information document. As seen in Figs. 19-21, Tback shows a distinct increase towards the end of each experiment. This occurs when sample burnout is observed; the time to burnout varies between repeated experiments conducted by each institution. Measurements of Tback reported after sample burnout do not offer useful information for further analysis, thus average Tback curves are only calculated (and plotted in Fig. 22) prior to this event.
+Figure~\ref{Cone-Calorimeter-all-fluxes_TEMP} plots average Tback curves from cone calorimeter tests conducted at 25, 50, and 65 kW/m$^2$. Back surface temperature measurements from cone calorimeter experiments conducted by all labs and under all external heating conditions (both individual measurements and average values, plotted with associated uncertainties) are supplied in the Supplemental Information document. As seen in Figs. ~\ref{Fig:Cone_25kWindivTEMP}-~\ref{Fig:Cone_65kWindivTEMP}, Tback shows a distinct increase towards the end of each experiment. This occurs when sample burnout is observed; the time to burnout varies between repeated experiments conducted by each institution. Measurements of Tback reported after sample burnout do not offer useful information for further analysis, thus average Tback curves are only calculated (and plotted in Fig. ~\ref{Fig:Cone-Calorimeter-all-fluxes_TEMP}) prior to this event.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Cone-Calorimeter-all-fluxes_TEMP}
   \caption{Comparison of average back surface temperatures in cone calorimeter tests at incident heat fluxes of q”ext = 25, 50, and 65 kW-2. Average curves are calculated using all submitted data from tests conducted under the same conditions, excluding outliers, as noted above. Shaded areas represent $2\sigma_{mean}$; error bars are not shown at q”ext = 50~kW/m$^2$ because only one measurement of Tback was reported at this heat flux.}
-  \label{Fig_22}
+  \label{Fig:Cone-Calorimeter-all-fluxes_TEMP}
 \end{figure}
 
 
 \paragraph{Tabulated values of interest:}
 
-Time to ignition, $t_{\rm ign}$, in each cone calorimeter experiment was defined as the first time at which $HRR \ge 24$ kW/m$^2$ [Lyon, 2007]. The arithmetic mean and standard deviation of this time to ignition is reported in Table 12 for repeated measurements from all institutions that submitted cone calorimeter data. Here, uncertainties are reported as one standard deviation, calculated as $Stdev=\sqrt{\frac{\sum\left(t_{ign}-\bar{t_{ign}}\right)^2}{(n-1)}}$, where n is the number of repeated tests conducted by an institution at a given heat flux and $\bar{t_{ign}}$ is the mean tign of each of these tests.
+Time to ignition, $t_{\rm ign}$, in each cone calorimeter experiment was defined as the first time at which $HRR \ge 24$ kW/m$^2$ \cite{lyon2007criteria}. The arithmetic mean and standard deviation of this time to ignition is reported in Table 12 for repeated measurements from all institutions that submitted cone calorimeter data. Here, uncertainties are reported as one standard deviation, calculated as $Stdev=\sqrt{\frac{\sum\left(t_{ign}-\bar{t_{ign}}\right)^2}{(n-1)}}$, where n is the number of repeated tests conducted by an institution at a given heat flux and $\bar{t_{ign}}$ is the mean tign of each of these tests.
 
 \begin{table}[ht]
 \caption{Ignition times (s) in Cone Calorimeter Tests}
@@ -789,7 +905,7 @@ Sherbrooke               & 148      & 4$^A$                  & -         & -    
 \end{tabular}
 \end{center}
 $^A$Calculated based on two values     \\
-$^B$Suspected error in submitted dataset, see Fig.~\ref{Fig_17}
+$^B$Suspected error in submitted dataset, see Fig.~\ref{Fig:Cone_65kWindiv}
 \end{table}
 
 Heat of combustion, $\Delta H_{\rm c}$, was calculated based on cone calorimeter measurements as the total energy released per gram of gaseous volatiles produced [kJ/g] during the time period at which $HRR \ge 240$ kW/m$^2$ (i.e., ten times the critical ignition HRR). The arithmetic mean and standard deviation of $\Delta H_{\rm c}$ is reported in Table 13 for repeated measurements from all institutions that submitted cone calorimeter data. Here, uncertainties are reported as one standard deviation, calculated as $Stdev=\sqrt{\frac{\sum\left(\mathrm{\Delta}H_c-\bar{\mathrm{\Delta}H_c}\right)^2}{(n-1)}}$, where n is the number of repeated tests conducted by an institution at a given heat flux and $\bar{\Delta H_{\rm c}}$ is the mean $\Delta H_{\rm c}$ of each of these tests.
@@ -818,7 +934,7 @@ Sherbrooke                              & 24.9$^B$ & 0.2$^B$                & - 
 \end{center}
 $^A$Tests were repeated three times using disc-shaped samples of diameter, $D = 7$ cm \\
 $^B$Calculated based on two values \\
-$^C$Suspected error in submitted dataset, see Figs.~\ref{Fig_15} and \ref{Fig_17} \\
+$^C$Suspected error in submitted dataset, see Figs.~\ref{Fig:Cone_25kWindivHRR} and \ref{Fig:Cone_65kWindivHRR} \\
 NC – Not Calculated due to low data reporting resolution
 \end{table}
 
@@ -828,7 +944,7 @@ NC – Not Calculated due to low data reporting resolution
 
 Anaerobic gasification experiments were conducted by six institutions using three different experimental apparatus. Key measurement data from anaerobic gasification tests include: gasification mass flux (dm”/dt [g s-1m-2]) and back surface temperature (Tback, [K]). Each quantity was reported as a time-resolved measurement.
 
-It should be noted that, although plotted together in this section, measured mass loss rates and back surface temperatures may not be identical between different gasification tests, even at the same nominal incident heat flux due to differences in (a) heating element and (b) back surface boundary conditions. Specifically, as described in Section 2.2 of this report, the FPA heating element operates at a higher temperature and thus emits IR radiation at a lower wavelength than that of the cone calorimeter heater, which is also used in CAPA II experiments. CAPA II tests, however, are unique in that samples are not insulated at their back surface and, thus, this surface is subject of convective and radiative losses defined elsewhere [Swan, FSJ, 2017].
+It should be noted that, although plotted together in this section, measured mass loss rates and back surface temperatures may not be identical between different gasification tests, even at the same nominal incident heat flux due to differences in (a) heating element and (b) back surface boundary conditions. Specifically, as described in Section 2.2 of this report, the FPA heating element operates at a higher temperature and thus emits IR radiation at a lower wavelength than that of the cone calorimeter heater, which is also used in CAPA II experiments. CAPA II tests, however, are unique in that samples are not insulated at their back surface and, thus, this surface is subject of convective and radiative losses defined elsewhere \cite{swann2017controlled}.
 
 One institution conducted anaerobic gasification experiments using CAPA II. Tests were conducted at 25 and 60 kW/m$^2$; tests were repeated two times at each incident heat flux. Reported errors represent two standard deviations of the mean of the respective quantity. The temperature data were collected at 7.5 Hz and presented here without any data processing. The mass data were collected at a frequency of 2 Hz. The mass loss rate was computed using a 5 s time differential and normalized by the initial top surface area of the sample. The data were subsequently grouped into 5 s bins for which mean MLR and mean time values were computed. More information is available at [Fiola et al., submitted 2020]. For tests conducted with a Controlled Atmosphere Cone Calorimeter or a Fire Propagation Apparatus (FPA), experimental measurements are analyzed together as described below.
 
@@ -844,33 +960,34 @@ Prior to further analysis, noise in individual HRR curves (at 1Hz) was reduced b
 \end{equation}
 where N = number of individual data points across the interval $i-2\le i\le i+2$
 Type A uncertainties are reported for all data as two standard deviations of the mean, $\sigma_{mean}$, calculated from repeated measurements across the time interval +/- ni. For $dm''/dt$ measurements, standard deviation of the mean was similarly calculated at each time step as per equation 16:
+%'...as per eqn. 16:' gets separated from the rest of the text. Does not make sense as formated
 \begin{equation}
    \sigma_{mean,\ \left.\ \frac{dm''}{dt}\right|_{{t=t}_i}}=\sqrt{\frac{\sum_{j}\sum_{i-n_i}^{i+n_i}\left(\left(\left.\ \frac{dm''}{dt}\right|_{{t=t}_i}\right)_j-\left.\ \left(\frac{dm''}{dt}\right)_{mean}\right|_{t=t_i}\right)^2}{N\left(N-1\right)}}
 \end{equation}
 Average values of $dm''/dt$ (and related $\sigma_{mean}$) were calculated with $ni =2$, as it is assumed that variations in these repeated measurements should be minimal within a +/- 2 s interval. Note: Chicoutimi data was submitted at 0.2 Hz, so when mean and standard deviation of the mean of these measurements are calculated, only 1 data point is available in this interval from each test at each time step.
 
 
-Figures 23, 24, and 25 plot measured sample-area normalized mass loss rate ($dm''/dt$) during anaerobic gasification experiments conducted with an external heat flux, q”ext =  25, 50, and 60 or 65 kW/m$^2$, respectively. Shaded areas represent $2\sigma_{mean}$. Test type (i.e., apparatus) and q”ext are noted in the legend of each figure; here, “Gasification” indicates that a given test was conducted in a controlled atmosphere cone calorimeter modified for gasification experiments.
+Figures ~\ref{Fig:Gasification_25kW_dmdt},~\ref{Fig:Gasification_50kW_dmdt}, and ~\ref{Fig:Gasification_65kW_dmdt} plot measured sample-area normalized mass loss rate ($dm''/dt$) during anaerobic gasification experiments conducted with an external heat flux, q”ext =  25, 50, and 60 or 65 kW/m$^2$, respectively. Shaded areas represent $2\sigma_{mean}$. Test type (i.e., apparatus) and q”ext are noted in the legend of each figure; here, “Gasification” indicates that a given test was conducted in a controlled atmosphere cone calorimeter modified for gasification experiments.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=4in]{SCRIPT_FIGURES/Gasification_25kW_dmdt_smoothed}
   \caption{Measured sample-area normalized mass loss rate (dm”/dt) during anaerobic gasification experiments with q”ext = 25 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$.}
-  \label{Fig_23}
+  \label{Fig:Gasification_25kW_dmdt}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=4in]{SCRIPT_FIGURES/Gasification_50kW_dmdt_smoothed}
   \caption{Measured sample-area normalized mass loss rate (dm”/dt) during anaerobic gasification experiments with q”ext = 50 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$.}
-  \label{Fig_24}
+  \label{Fig:Gasification_50kW_dmdt}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=4in]{SCRIPT_FIGURES/Gasification_65kW_dmdt_smoothed}
   \caption{Measured sample-area normalized mass loss rate (dm”/dt) during anaerobic gasification experiments with q”ext = 60 or 65 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$.}
-  \label{Fig_25}
+  \label{Fig:Gasification_65kW_dmdt}
 \end{figure}
 
 
@@ -887,34 +1004,34 @@ For Tback and Tfront measurements, standard deviation of the mean was calculated
 \end{equation}
 Mean and standard deviation values of Tback were calculated with ni =2, as it is assumed that variations in these repeated measurements should be minimal within a +/- 2 s interval. Note: ‘Chicoutimi’ data was submitted at 0.2 Hz, so when mean and standard deviation of the mean of these measurements are calculated, only 1 data point is available in this interval from each test at each time step.
 
-Figures~\ref{Fig_26}, \ref{Fig_27}, and \ref{Fig_28} plot measured sample surface temperature measurements obtained during anaerobic gasification experiments conducted with an external heat flux, q”ext =  25, 50, and 60 or 65 kW/m$^2$, respectively. Shaded areas represent $2\sigma_{\rm mean}$. Test type (i.e., apparatus), external heat flux, and measurement location are noted in the legend and/or caption of each figure. ``Gasification'' indicates that a given test was conducted in a controlled atmosphere cone calorimeter modified for gasification experiments.
+Figures~\ref{Fig:Gasification_25kW_Temperature}, \ref{Fig_Gasification_50kW_Temperature}, and \ref{Fig:Gasification_65kW_Temperature} plot measured sample surface temperature measurements obtained during anaerobic gasification experiments conducted with an external heat flux, q”ext =  25, 50, and 60 or 65 kW/m$^2$, respectively. Shaded areas represent $2\sigma_{\rm mean}$. Test type (i.e., apparatus), external heat flux, and measurement location are noted in the legend and/or caption of each figure. ``Gasification'' indicates that a given test was conducted in a controlled atmosphere cone calorimeter modified for gasification experiments.
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Gasification_25kW_Temperature}
   \caption{Measured front (‘Charlottetown’) or back (‘Chicoutimi’ and ‘Saint John’) surface temperature during anaerobic gasification experiments conducted at q”ext = 25 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$. \\
 ‘Charlottetown’:  FPA (q”ext = 25 kW/m$^2$); front surface temperature, Tfront \\
 ‘Chicoutimi’:   FPA (q”ext = 25 kW/m$^2$); back surface temperature, Tback \\
 ‘Saint-John’:   CAPA (q”ext = 25 kW/m$^2$); back surface temperature, Tback}
-  \label{Fig_26}
+  \label{Fig:Gasification_25kW_Temperature}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Gasification_50kW_Temperature}
   \caption{Measured front surface temperature (Tfront) during FPA experiments conducted at q”ext = 50 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$.}
-  \label{Fig_27}
+  \label{Fig:Gasification_50kW_Temperature}
 \end{figure}
 
 \begin{figure}
   \centering
-  \includegraphics[width=4in]{SCRIPT_FIGURES/PMMA_40}
+  \includegraphics[width=5.5in]{SCRIPT_FIGURES/Gasification_65kW_Temperature}
   \caption{Measured front (‘Charlottetown’) or back (‘Baie-Comeau’, ‘Chicoutimi’, and ‘Saint John’) surface temperature during anaerobic gasification experiments conducted at q”ext = 60 or 65 kW/m$^2$. Shaded areas represent $2\sigma_{mean}$. \\
  ‘Baie-Comeau’:  Controlled Atmosphere Cone Calorimeter (q”ext = 65 kW/m$^2$). back surface temperature, Tback \\
 ‘Charlottetown’:  FPA (q”ext = 65 kW/m$^2$); front surface temperature, Tfront \\
 ‘Chicoutimi’:   FPA (q”ext = 65 kW/m$^2$); back surface temperature, Tback \\
 ‘Saint-John’:   CAPA (q”ext = 60 kW/m$^2$); back surface temperature, Tback}
-  \label{Fig_28}
+  \label{Fig:Gasification_65kW_Temperature}
 \end{figure}
 
 
@@ -978,68 +1095,8 @@ PMMA 2  & 0.112 & 0.112 & 0.110 & 0.108 & 0.107 & 0.106 & 0.104 & 0.103 & 0.101 
 
 \chapter{References}
 
-%\bibliography{}
+%\bibliography{MaCFP2021_Part1_Exp_bib}
 
-ASTM International, “E1354-17 Standard Test Method for Heat and Visible Smoke Release Rates for Materials and Products Using an Oxygen Consumption Calorimeter,” West Conshohocken, PA; ASTM International, (2017)
-
-ASTM E2058-19, “Standard Test Methods for Measurement of Material Flammability Using a Fire Propagation Apparatus (FPA),” ASTM International, West Conshohocken, PA, (2019)
-
-Babrauskas, V., Twilley, W. H., Janssens, M., Yusa, S, “A cone calorimeter for controlled‐atmosphere studies,” Fire and Materials, 16: pp. 37-43, (1992)
-
-Babrauskas, V., “Development of the cone calorimeter—a bench‐scale heat release rate apparatus based on oxygen consumption,” Fire and Materials 8: pp. 81-95 (1984)
-
-Babrauskas, V, “The cone calorimeter,” In SFPE handbook of fire protection engineering (pp. 952-980). Springer, New York, NY, (2016)
-
-Batiot, B. Bruns, M., Hostikka, S., Leventon, I., Nakamura, Y., Reszka, P., Rogaume, T., Stoliarov, S., “Guidelines for Participation in the 2021 Condensed Phase Workshop, version 1.2” IAFSS. Accessed, July 2020: http://iafss.org/macfp-condensed-phase-phenomena/ (2020)
-
-Brown, A., Bruns, M., Gollner, M., Hewson, J., Maragkos, G., Marshall, A., McDermott, R. Merci, B., Rogaume, T., Stoliarov, S., Torero, J., Trouvé, A., Wang, Y., Weckman, E., “Proceedings of the first workshop organized by the IAFSS Working Group on Measurement and Computation of Fire Phenomena (MaCFP),” Fire Safety Journal 101: pp. 1-17 (2018)
-
-Brown, M.  ‘Introduction to Thermal Analysis: Techniques and Applications,” Kluwer Academic Publishers, New York (2001)
-
-Coats, A. W., Redfern, J. P., "Thermogravimetric analysis. A review." Analyst 88: pp. 906-924 (1963)
-
-Consalvi, J.L.,Pizzo, T., Porterie,B., “Numerical analysis of the heating process in upward flame spread over thick PMMA slabs,” Fire Safety Journal Volume 43: pp. 351-362 (2008)
-
-Fiola, G.J., Chaudhari, D.M., Stoliarov, S.I., "Comparison of Pyrolysis properties of extruded and cast Poly (methyl methacrylate)," submitted to IAFSS 2020 (2020)
-
-Fukumoto, K. Wang, C., Wen, J., “Large eddy simulation of upward flame spread on PMMA walls with a fully coupled fluid–solid approach, Combustion and Flame Volume 190: pp. 365-387 (2018)
-
-Gustafsson, S. E., “Transient plane source techniques for thermal conductivity and thermal diffusivity measurements of solid materials,” Review of Scientific Instruments 62: pp. 797-804, (1991)
-
-Hirata, T., Kashiwagi, T., Brown, J.E., “Thermal and Oxidative Degradation of Poly(methylmethacrylate): Weight Loss,” Macromolecules Volume 18: pp. 1410-1418 (1985)
-
-Kashiwagi, T., Ohlemiller, T.J., “A study of oxygen effects on nonflaming transient gasification of PMMA and PE during thermal irradiation,” Symposium (International) on Combustion Volume 19: pp. 815-823 (1982)
-
-Leventon, I.T., Li, J., Stoliarov, S.I., “A flame spread simulation based on a comprehensive solid pyrolysis model coupled with a detailed empirical flame structure representation,” Combustion and Flame Volume 162: pp. Pages 3884-3895 (2015)
-
-Lyon, R. E., Walters, R. N., Stoliarov, S. I., Safronava, N., "Principles and practice of microscale combustion calorimetry," Federal Aviation Administration: Atlantic City International Airport, NJ, USA (2013)
-
-Lyon, R. E., Quintiere, J. G., “Criteria for piloted ignition of combustible solids,” Combustion and Flame 151: pp. 551-559, (2007)
-
-Matala, A., Lautenberger, C., Hostikka, S., “Generalized direct method for pyrolysis kinetic parameter estimation and comparison to existing methods,” Journal of Fire Sciences 30: pp. 339-356 (2012)
-
-McNaughton, J. L., Höhne, G., Hemminger, W., Flammersheim, H. J., Flammersheim, H. J., “Differential scanning calorimetry,” Springer Science \& Business Media (2003)
-
-Netzsch GmbH, “Light Flash Apparatus LFA 467 HyperFlash Series: Method, Technique, Applications of Thermal Diffusivity and Thermal Conductivity”, NETZSCH-Gerätebau GmbH, Selb, Germany
-
-Nyazika, T., Jimenez, M., Samyn, F., Bourbigot, S., “Pyrolysis modeling, sensitivity analysis, and optimization techniques for combustible materials: A review,” Journal of Fire Sciences 37: pp. 377-433 (2019)
-
-Rhodes, B.T., Quintiere, J.G., “Burning rate and flame heat flux for PMMA in a cone calorimeter,” Fire Safety Journal Volume 26: pp. 221-240 (1996)
-
-Rogaume, T., “Thermal decomposition and pyrolysis of solid fuels: Objectives, challenges and modelling,” Fire Safety Journal 106: pp. 177-188 (2019)
-
-Stoliarov, S., Li, J., “Parameterization and Validation of Pyrolysis Models for Polymeric Materials,” Fire Technology, 52: 72-91 (2016)
-
-Swann, J. D., Ding, Y., McKinnon, M. B., \& Stoliarov, S. I. (2017). Controlled atmosphere pyrolysis apparatus II (CAPA II): A new tool for analysis of pyrolysis of charring and intumescent polymers. Fire Safety Journal, 91, 130-139.
-
-Taylor, B. N., Kuyatt, C. E., “NIST Technical Note 1297: Guidelines for evaluating and expressing the uncertainty of NIST measurement results,” National Institute for Standards and Technology, (1994)
-
-Tewarson, A., Ogden, S..”Fire behavior of polymethylmethacrylate,” Combustion and Flame Volume 89: pp. 237-259 (1992)
-
-Vermina Plathner, F., Van Hees, P., “Experimental assessment of bench‐scale ignitability parameters,” Fire and Materials 43: 123-130 (2019)
-
-
-Witkowski, A., Stec, A., Hull, T., “Thermal Decomposition of Polymeric Materials,” SFPE Handbook 5th Edition, Hurley, M.J. ed., pp. 167-254 (2016)
 
 
 


### PR DESCRIPTION
Updated figure and citation references across the document. 
It took this long 50/50 b/c (a) it's a tedious process (b) I'm working through the learning curve. Thank you for making the original conversion from .docx to .tex, that helped immensely.

For figures with subfigures (e.g. Mass and MLR data from TGA data plotted above one another; pgs 16-19), I realized there's a lot of blank space in between plots. This is apparently a Matlab print to pdf issue - *all* the plots are letter sized, not cropped to the image itself. I'll work on this tomorrow and upload new copies to the drive as needed.

Eventually, will need to redo table numbering just as the figures were done here. Looks like a number of subscripts disappeared too. It's late and I'll work on these two another day.