### PR TITLE
Update MaCFP_2021_Report_Part_I_Experimental.tex

### DIFF
--- a/Documents/MaCFP_2021_Report_Part_I_Experimental.tex
+++ b/Documents/MaCFP_2021_Report_Part_I_Experimental.tex
@@ -441,7 +441,7 @@ As shown here, the actual heating rate can vary significantly during the early s
 
 \subsubsection{Mass Fraction and Mass Loss Rate}
 
-The key measurements recorded during TGA tests are sample mass, $m$~(mg); temperature, $T$~(K); and the time, $t$~(s), at which these two values are recorded.  Both $m$ and $T$ were reported as time-resolved measurements. Prior to further analysis, sample mass was normalized by initial mass, $m_0$, which was calculated as the mean value recorded during the first 5~s of the experiment.
+The key measurements recorded during TGA tests are sample mass, $m$~(mg); temperature, $T$~(K); and the time, $t$~(s), at which these two values are recorded.  Both $m$ and $T$ were reported as time-resolved measurements. Prior to further analysis, sample mass was normalized by initial mass, $m_0$, which was calculated as the mean value over the first 5 data points of the respective experiment data file.
 
 Tests were run, nominally, at constant heating rates and both sample mass and temperature were reported at regular time or temperature intervals; effectively this meant that sample mass was reported, in most experiments, every 0.5~K (the full range of reporting frequencies in datasets submitted by different institutions varied between 0.1~K and 1~K per mass measurement, with two institutions submitting data with 5~K or 6.7~K resolutions). Reporting frequency was not necessarily constant and, due to the nature of the experiment, measured sample temperature could actually decrease from one time step to the next.
 


### PR DESCRIPTION
Corrected the description of calculating the initial mass as mean value of the TGA experiments from the first five data points, instead of seconds.