### PR TITLE
matl-db analysis scripts - edits to begin transition to name-based indexing

### DIFF
--- a/Scripts/DSC_Analysis.m
+++ b/Scripts/DSC_Analysis.m
@@ -37,7 +37,7 @@ for i =1:N_files   % Loop through all of your data sets
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=6 && m<=16        % Just DSC Tests
+    if contains(filenames{i},"DSC")==1        % Just DSC Tests
 
         T_start=ceil(min(EXP_DATA{k,L,m}(:,2)));            %find first timestep (rounded to nearest integer)
         T_end=floor(max(EXP_DATA{k,L,m}(:,2)));             %find last timestep (rounded to nearest integer)
@@ -100,7 +100,7 @@ for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=6 && m<=16        % Just DSC Tests
+    if contains(filenames{i},"DSC")==1          % Just DSC Tests
     temp=min(EVAL_DATA{k,L,m}(:,2));
     if temp>min_T
         min_T=temp;
@@ -116,7 +116,7 @@ clear temp
 %     k=files{i,3};   % Find Lab Name
 %     L=files{i,4};   % Find Test Count
 %     m=files{i,2};   % Find Test Type
-%     if m>=6 && m<=16 && k~=14       % Just DSC Tests // UMET data has unique /\/\/\ temperature program
+%     if contains(filenames{i},"DSC")==1   && contains(filenames{i},"UMET")==1        % Just DSC Tests // UMET data has unique /\/\/\ temperature program
 %         T_check(i,1)=min(EVAL_DATA{k,L,m}(:,2)); %min_T
 %         T_check(i,2)=max(EVAL_DATA{k,L,m}(:,2)); %max_T
 %         T_check(i,3)=k;
@@ -135,7 +135,7 @@ for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=6 && m<=16 && k~=14       % Just DSC Tests // UMET data has unique /\/\/\ temperature program
+    if contains(filenames{i},"DSC")==1 && contains(filenames{i},"UMET")==0       % Just DSC Tests // UMET data has unique /\/\/\ temperature program
 
         last = min(min(N_rows_all(k,:,m)-1,511));
 
@@ -174,7 +174,7 @@ for i=1:N_files
 %             HRR25(1:last,L+2,k)=sgolayfilt(HRR25(1:last,L+2,k),3,15);,
             clear temp_MLR temp_Mass
 
-            if k==13    % plot UMD with their own error bars
+            if contains(filenames{i},"UMD")==1       % plot UMD with their own error bars
                 shadedErrorBar(EXP_DATA{k,L,m}(:,2),EXP_DATA{k,L,m}(:,3),[EXP_DATA{k,L,m}(:,4) EXP_DATA{k,L,m}(:,4)],'lineprops', {'k','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
                 axis([300 800 -inf inf]);
 %                 title({QMJHL{k} Test_types{m}}, 'interpreter', 'none');     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed; QMJHL Names
@@ -250,7 +250,7 @@ for i =1:N_files   % Loop through all of your data sets
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m== 28 | m== 30| m>=35
+    if contains(filenames{i},["TGA_N2_10K","TGA_N2_20K","TGA_Ar_1K","TGA_Ar_10K","TGA_Ar_50K"])==1
         T_start=ceil(min(EXP_DATA{k,L,m}(:,2)));   %find first timestep (rounded to nearest integer)
         T_end=floor(max(EXP_DATA{k,L,m}(:,2)));     %find last timestep (rounded to nearest integer)
         m0=mean(EXP_DATA{k,L,m}(1:5,3));            % define m0 as average m from first five timesteps
@@ -310,7 +310,7 @@ for i =1:N_files   % Loop through all of your data sets
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m== 10 && (k==5 || k==8 || k== 10 || k==13)   %N2_10K
+    if contains(filenames{i},"DSC_N2_10K")==1 && contains(filenames{i},["TGA_N2_10K","TGA_N2_20K","TGA_Ar_1K","TGA_Ar_10K","TGA_Ar_50K"])==1 (k==5 || k==8 || k== 10 || k==13)   %N2_10K
         T_onset=TAB_DATA{28,3}(k,L);
         T_endset=TAB_DATA{28,4}(k,L);
         i_onset=find((EVAL_DATA{k,L,m}(:,2))==T_onset,1);
@@ -320,7 +320,7 @@ for i =1:N_files   % Loop through all of your data sets
         TAB_DATA{m,1}(k,L)=(int_heat_rxn-baseline)/TAB_DATA{28,5}(k,L);
         clear   T_onset  T_endset i_onset i_endset baseline int_heat_rxn
 
-    elseif m== 11 && k==2   %N2_20K
+    elseif contains(filenames{i},"DSC_N2_20K")==1 && k==2   %N2_20K
         T_onset=TAB_DATA{30,3}(k,L);
         T_endset=TAB_DATA{30,4}(k,L);
         i_onset=find((EVAL_DATA{k,L,m}(:,2))==T_onset,1);
@@ -330,7 +330,7 @@ for i =1:N_files   % Loop through all of your data sets
         TAB_DATA{m,1}(k,L)=(int_heat_rxn-baseline)/TAB_DATA{30,5}(k,L);
         clear   T_onset  T_endset i_onset i_endset baseline int_heat_rxn
 
-    elseif m>=14 && m<=16 && k==9   %Ar_1,10,50K
+    elseif contains(filenames{i},["DSC_Ar_1K","DSC_Ar_10K","DSC_Ar_50K"])==1 && k==9   %Ar_1,10,50K
         T_onset=TAB_DATA{m+21,3}(k,L);
         T_endset=TAB_DATA{m+21,4}(k,L);
         i_onset=find((EVAL_DATA{k,L,m}(:,2))==T_onset,1);
@@ -352,8 +352,8 @@ hold on
 m=10;
 i_legend=1;
 for k=1:N_Labs
-    if Test_count(m,k)~=0 && k~=14  %(14 is UMET, that data is /\/\/\)
-        if k==8   % because you're averaging together your NIST data and only showing that combined curve, this needed to be updated accordingly
+    if Test_count(m,k)~=0 && contains(filenames{i},'UMET')==0    %(UMET data is /\/\/\)
+        if contains(filenames{i},"NIST")==1   % because you're averaging together your NIST data and only showing that combined curve, this needed to be updated accordingly
             legend_counter(i_legend)=k;
             i_legend=i_legend+1;           
         else 
@@ -368,10 +368,10 @@ for i=1:N_files
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
     last = min(min(N_rows_all(k,:,m)-1,511));
-    if m==10 && k~=14  && L==Test_count(m,k)  % Just DSC Tests // UMET data is messed up /\/\/\ temperature program
+    if contains(filenames{i},"DSC_N2_10K")==1 && contains(filenames{i},"UMET")==0  && L==Test_count(m,k)  % Just DSC Tests // UMET data is different, /\/\/\ // temperature program
         hold on
         figure(1)    
-        if k==13
+        if contains(filenames{i},"UMD")==1
             figure(1)
             shadedErrorBar(EXP_DATA{k,L,m}(:,2),EXP_DATA{k,L,m}(:,3),[EXP_DATA{k,L,m}(:,4) EXP_DATA{k,L,m}(:,4)],'lineprops', {'M','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
             figure(2)
@@ -379,13 +379,13 @@ for i=1:N_files
 %             plot(DSC_Temperature(1:last),DSC_int_heatflow(1:last,1,k,m),'-','MarkerSize',5,'color',rgb(Colors{k}),'DisplayName',QMJHL{k});
             plot(DSC_Temperature(1:last),DSC_int_heatflow(1:last,1,k,m),'-','MarkerSize',5,'color',rgb(Colors{k}),'DisplayName',LabNames{k});
 %             shadedErrorBar(DSC_Temperature(1:last),DSC_int_heatflow(1:last,L+2,k,m),[2*DSC_int_heatflow(1:last,L+4,k,m) 2*DSC_int_heatflow(1:last,L+4,k,m)],'lineprops', {'M','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
-        elseif k==8         
+        elseif contains(filenames{i},"NIST")==1         
             figure(1)
             shadedErrorBar(DSC_Temperature(1:last),DSC_heatflow(1:last,L+2,k,m),[2*DSC_heatflow(1:last,L+4,k,m) 2*DSC_heatflow(1:last,L+4,k,m)],'lineprops', {'k','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
             figure(2)
             shadedErrorBar(DSC_Temperature(1:last),DSC_int_heatflow(1:last,L+2,k,m),[2*DSC_int_heatflow(1:last,L+4,k,m) 2*DSC_int_heatflow(1:last,L+4,k,m)],'lineprops', {'k','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
         end        
-        if k~=8
+        if contains(filenames{i},"NIST")==0
             for ix=1:L
                 hold on
                 figure(1)        
@@ -444,7 +444,7 @@ col_old=0;
 i_legend=1;
 clear legend_counter
 for k=1:N_Labs
-    if Test_count(m,k)~=0 && k~=14 %(14 is UMET, that data is /\/\/\)
+    if Test_count(m,k)~=0 && contains(filenames{i},"UMET")==0 %(UMET DSC data is /\/\/\)
         col_new=Test_count(m,k);
         legend_counter(i_legend:i_legend+Test_count(m,k)-1)=k;
         col_old=col_old+col_new;
@@ -457,7 +457,7 @@ for i=1:N_files
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
     last = min(min(N_rows_all(k,:,m)-1,511));
-    if m==13 && k~=14  && L==Test_count(m,k)     % Just DSC Tests // UMET data is messed up /\/\/\ temperature program
+    if contains(filenames{i},"DSC_O2-21_10K")==1 && contains(filenames{i},"UMET")==0  && L==Test_count(m,k)     % Just DSC Tests // UMET DSC data is /\/\/\ temperature program
         hold on
         for ix=1:L
             figure(1)
@@ -516,7 +516,7 @@ for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=6 && m<=16 && k==14       % Just DSC Tests
+    if contains(filenames{i},"DSC")==1 && contains(filenames{i},"UMET")==1       % Just UMET DSC Tests
         hold on
         plot(EXP_DATA{k,L,m}(:,2),EXP_DATA{k,L,m}(:,3),col{ix});
         legend_UMET_DSC{ix,1}=Test_types{m};

--- a/Scripts/Gasification_Analysis.m
+++ b/Scripts/Gasification_Analysis.m
@@ -206,10 +206,12 @@ for i=1:length(legend_counter)
     str{i,1}={LabNames{legend_counter(i)},Test_types{legend_counter_test(i)}};
     legend_final{i,1}=strjoin(str{i}, ', ');
 end
-%manually add legen entry for CAPA Data
-shadedErrorBar(EXP_DATA{13,1,1}(:,1),EXP_DATA{13,1,1}(:,2),[EXP_DATA{13,1,1}(:,4) EXP_DATA{13,1,1}(:,4)],'lineprops', {'color', rgb(Colors{13}),'LineWidth',1}) % ADD in UMD CAPA DATA
-% str{end+1,1}={QMJHL{13},Test_types{1}};
-str{end+1,1}={LabNames{13},Test_types{1}};
+%manually add legend entry for CAPA Data
+k=find(LabNames=="UMD");
+shadedErrorBar(EXP_DATA{k,1,1}(:,1),EXP_DATA{k,1,1}(:,2),[EXP_DATA{k,1,1}(:,4) EXP_DATA{k,1,1}(:,4)],'lineprops', {'color', rgb(Colors{k}),'LineWidth',1}) % ADD in UMD CAPA DATA
+% str{end+1,1}={QMJHL{k},Test_types{1}};
+str{end+1,1}={LabNames{k},Test_types{1}};
+clear k
 legend_final{end+1}=strjoin(str{end}, ', ');
 % legend(QMJHL{[legend_counter 13]},'Location','eastoutside');
 legend(legend_final,'Location','northwest', 'Interpreter','none');
@@ -426,15 +428,16 @@ for i=1:N_files
         end
     end
 end
-
-shadedErrorBar(EXP_DATA{13,1,2}(:,1),EXP_DATA{13,1,2}(:,2),[EXP_DATA{13,1,2}(:,4) EXP_DATA{13,1,2}(:,4)],'lineprops', {'color', rgb(Colors{13}),'LineWidth',1}) % ADD in UMD CAPA DATA
+k=find(LabNames=="UMD");
+shadedErrorBar(EXP_DATA{k,1,2}(:,1),EXP_DATA{k,1,2}(:,2),[EXP_DATA{k,1,2}(:,4) EXP_DATA{k,1,2}(:,4)],'lineprops', {'color', rgb(Colors{k}),'LineWidth',1}) % ADD in UMD CAPA DATA
 for i=1:length(legend_counter)
     str{i,1}={QMJHL{legend_counter(i)},Test_types{legend_counter_test(i)}};
     str{i,1}={LabNames{legend_counter(i)},Test_types{legend_counter_test(i)}};
     legend_final{i,1}=strjoin(str{i}, ', ');
 end
-str{end+1,1}={LabNames{13},Test_types{2}};
-% str{end+1,1}={QMJHL{13},Test_types{2}};
+str{end+1,1}={LabNames{k},Test_types{2}};
+clear k
+% str{end+1,1}={QMJHL{k},Test_types{2}};
 legend_final{end+1}=strjoin(str{end}, ', ');
 % legend(QMJHL{[legend_counter 13]},'Location','eastoutside');
 legend(legend_final,'Location','northwest', 'Interpreter','none');
@@ -547,9 +550,11 @@ for i=1:length(legend_counter)
     legend_final{i,1}=strjoin(str{i}, ', ');
 end
 % Add in CAPA Data (custom error bars)
-shadedErrorBar(EXP_DATA{13,2,1}(:,1),EXP_DATA{13,2,1}(:,3),[EXP_DATA{13,2,1}(:,5) EXP_DATA{13,2,1}(:,5)],'lineprops', {'color', rgb(Colors{13}),'LineWidth',1}) % ADD in UMD CAPA DATA
-str{end+1,1}={LabNames{13},Test_types{1}};
-% str{end+1,1}={QMJHL{13},Test_types{1}};
+k=find(LabNames=="UMD");
+shadedErrorBar(EXP_DATA{k,2,1}(:,1),EXP_DATA{k,2,1}(:,3),[EXP_DATA{k,2,1}(:,5) EXP_DATA{k,2,1}(:,5)],'lineprops', {'color', rgb(Colors{k}),'LineWidth',1}) % ADD in UMD CAPA DATA
+str{end+1,1}={LabNames{k},Test_types{1}};
+% str{end+1,1}={QMJHL{k},Test_types{1}};
+k=find(LabNames=="UMD");
 legend_final{end+1}=strjoin(str{end}, ', ');
 % legend(QMJHL{[legend_counter 13]},'Location','eastoutside');
 legend(legend_final,'Location','southeast', 'Interpreter','none');
@@ -765,9 +770,11 @@ for i=1:length(legend_counter)
     legend_final{i,1}=strjoin(str{i}, ', ');
 end
 % Add in CAPA Data (custom error bars)
-shadedErrorBar(EXP_DATA{13,2,2}(:,1),EXP_DATA{13,2,2}(:,3),[EXP_DATA{13,2,2}(:,5) EXP_DATA{13,2,2}(:,5)],'lineprops', {'color', rgb(Colors{13}),'LineWidth',1}) % ADD in UMD CAPA DATA
-% str{end+1,1}={QMJHL{13},Test_types{2}};
-str{end+1,1}={LabNames{13},Test_types{2}};
+k=find(LabNames=="UMD");
+shadedErrorBar(EXP_DATA{k,2,2}(:,1),EXP_DATA{k,2,2}(:,3),[EXP_DATA{k,2,2}(:,5) EXP_DATA{k,2,2}(:,5)],'lineprops', {'color', rgb(Colors{k}),'LineWidth',1}) % ADD in UMD CAPA DATA
+% str{end+1,1}={QMJHL{k},Test_types{2}};
+str{end+1,1}={LabNames{k},Test_types{2}};
+clear k
 legend_final{end+1}=strjoin(str{end}, ', ');
 % legend(QMJHL{[legend_counter 13]},'Location','eastoutside');
 legend(legend_final,'Location','southeast', 'Interpreter','none');

--- a/Scripts/Import_data.m
+++ b/Scripts/Import_data.m
@@ -2,7 +2,7 @@ clear all
 
 %%Get information about what's inside your Repo.
 % %Specify where all your data is saved
-Root_dir=[pwd,'/../Non-charring/PMMA/'];
+Root_dir=[pwd,'/../PMMA/Calibration_Data'];
 Script_Figs_dir=[pwd,'/../Documents/SCRIPT_FIGURES/'];
 PMMA_Repo = dir(fullfile(Root_dir,'*/*.csv'));
 
@@ -28,12 +28,12 @@ dirIndex(1:2)=0;
 LabNames={dirData(dirIndex).name}';
 
 % Create corresponding list of anonymous names for each institution
-QMJHL={'Baie-Comeau' 'Blainville-Boisbriand' 'Cape-Breton' 'Charlottetown' 'Chicoutimi' 'Drummondville'...
-    'Gatineau' 'Halifax' 'Moncton' 'Quebec' 'Rimouski' 'Rouyn-Noranda' 'Saint John' 'Shawinigan'...
-    'Sherbrooke'  'Val dOr' 'Victoriaville'}';
+QMJHL={'Acadie-Bathurst' 'Baie-Comeau' 'Belleville' 'Blainville-Boisbriand' 'Cape-Breton' 'Charlottetown' ...
+    'Chicoutimi' 'Drummondville' 'Gatineau' 'Halifax' 'Kitchner' 'Moncton' 'Quebec' 'Rimouski' 'Rouyn-Noranda' 'Saginaw' ...
+    'Saint John' 'Shawinigan' 'Sherbrooke'  'Sudbury' 'Val dOr' 'Victoriaville'}';
 % Create corresponding list of colors for each dataset submitted by a given institution
 Colors={'DarkViolet' 'Gray' 'Red' 'OrangeRed' 'Gold' 'Green' 'Blue' 'Black' 'DeepSkyBlue' ...
-    'Indigo' 'Lime' 'Navy' 'DeepPink' 'DarkRed' 'Cyan' 'Magenta' 'Khaki'}';
+    'Indigo' 'Lime' 'Navy' 'DeepPink' 'DarkRed' 'Cyan' 'Magenta' 'Khaki' 'DarkGreen' 'darkorange' 'tea' 'goldenrod'}';
 
 N_Labs=size(LabNames,1);
 Asurf=csvread('Asurf.txt');  % Note: DBI/LUND (LabNames{2}) has two different sample areas for CONE data (here atleast, HRR data is already normalized as [kW/m2])

--- a/Scripts/TGA_Analysis.m
+++ b/Scripts/TGA_Analysis.m
@@ -32,7 +32,7 @@ for i =1:N_files   % Loop through all of your data sets
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=24        % TGA Tests
+    if contains(filenames{i},"TGA")==1        % TGA Tests
         T_start=ceil(min(EXP_DATA{k,L,m}(:,2)));   %find first timestep (rounded to nearest integer)
         T_end=floor(max(EXP_DATA{k,L,m}(:,2)));     %find last timestep (rounded to nearest integer)
         m0=mean(EXP_DATA{k,L,m}(1:5,3));            % define m0 as average m from first five timesteps
@@ -94,11 +94,11 @@ for i =1:N_files   % Loop through all of your data sets
                yyaxis right
         plot(EVAL_DATA{k,L,m}(:,2),EVAL_DATA{k,L,m}(:,4),'k');
         axis([300 900 0 6e-3]);
-        if i~= 113
-        title(filenames{i}, 'interpreter', 'none');     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed
-        else
-            title('Halifax_TGA_N2_10K_1');     %Example NIST/Halifax data anonymously for Prelim. Exp. Report
-        end
+%         if i~= 113
+%         title(filenames{i}, 'interpreter', 'none');     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed
+%         else
+%             title('Halifax_TGA_N2_10K_1');     %Example NIST/Halifax data anonymously for Prelim. Exp. Report
+%         end
         xlabel('Temperature [K]');
         ylabel('(1/m_0)dm/dt [s^{-1}]');
         legend({'m/m_0','m/m_0, filtered','d(m/m_0)/dt','d(m/m_0)/dt, filtered'},'Location','west')
@@ -146,15 +146,17 @@ close all
 %p=1 --> max(dm*/dt)
 %p=2 --> T_max(dm*/dt)
 %p=3 --> T_onset (10% of max dm*/dt)
-for m=24:37
-    for p=1:3
-        N_Labs_TGA=size(TAB_DATA{m,p},1);
-        temp=TAB_DATA{m,p}(:,:);
-        temp(temp==0)=NaN;
-        TAB_DATA{m,p}(:,:)=temp;
-        for k=1:N_Labs_TGA
-            TAB_DATA{m,p}(k,max(max(Test_count(m,p:N_Labs_TGA)))+1)=mean(TAB_DATA{m,p}(k,1:max(max(Test_count(m,p:N_Labs_TGA)))),'omitnan');       %Calculate mean of t_ignition for this lab
-            TAB_DATA{m,p}(k,max(max(Test_count(m,p:N_Labs_TGA)))+2)=std(TAB_DATA{m,p}(k,1:max(max(Test_count(m,p:N_Labs_TGA)))),'omitnan');       %Calculate stdev of t_ignition for this lab
+for m=1:N_test_types    
+    if contains(Test_types{m},"TGA")==1
+        for p=1:3
+            N_Labs_TGA=size(TAB_DATA{m,p},1);
+            temp=TAB_DATA{m,p}(:,:);
+            temp(temp==0)=NaN;
+            TAB_DATA{m,p}(:,:)=temp;
+            for k=1:N_Labs_TGA
+                TAB_DATA{m,p}(k,max(max(Test_count(m,p:N_Labs_TGA)))+1)=mean(TAB_DATA{m,p}(k,1:max(max(Test_count(m,p:N_Labs_TGA)))),'omitnan');       %Calculate mean of t_ignition for this lab
+                TAB_DATA{m,p}(k,max(max(Test_count(m,p:N_Labs_TGA)))+2)=std(TAB_DATA{m,p}(k,1:max(max(Test_count(m,p:N_Labs_TGA)))),'omitnan');       %Calculate stdev of t_ignition for this lab
+            end
         end
     end
 end
@@ -162,7 +164,7 @@ clear temp N_Labs_cone
 
 %p=3 --> T_onset (10% of max dm*/dt)
 figure
-    histogram(TAB_DATA{28,3}([1:9,11,13:15],1:3),10) % Remove TIFP, UDRI
+    histogram(TAB_DATA{28,3}([1:11,13,15:end],1:3),10) % Remove TIFP, UDRI
         title("Onset Temperature of Decomposition (TGA in N_2)");     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed
 %         axis([60 160 0 10]);
         xlabel('Temperature [K]');
@@ -176,7 +178,7 @@ figure
 
 %p=2 --> T_max(dm*/dt)
         figure
-    histogram(TAB_DATA{28,2}([1:9,11,12:end],1:3),12)             % Remove TIFP, UDRI
+    histogram(TAB_DATA{28,2}([1:11,13,15:end],1:3),12)             % Remove TIFP, UDRI
         title("Temperature of peak MLR (TGA in N_2)");     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed
 %         axis([60 160 0 10]);
         xlabel('Temperature [K]');
@@ -192,7 +194,7 @@ figure
 figure
 hold on
 i_legend=0;
-all_marks = {'o','+','*','h','x','s','d','^','v','>','<','p','.'};
+all_marks = {'o','+','*','h','x','s','d','^','v','>','<','p','.','o','+','*','h','x','s','d','^','v','>','<','p','.'};
 for k=1:N_Labs
         if Test_count(28,k)~=0    %If this dataset is the last one for this lab, do some statistics
             i_legend=i_legend+1;
@@ -203,13 +205,13 @@ end
 
 
 %         title("Onset Temperature of Decomposition (TGA in N_2)");     %title the figure based on the name of dataset i; turn off interpreter so _ is explicitly displayed
-        axis([620 655 0 3.25e-3]);
+        axis([620 655 0 3.5e-3]);
         box on
         xlabel('T_{max} [K]');
         ylabel('Peak Mass Loss Rate (s^{-1})');
-        legend(LabNames{legend_counter},'Location','southwest'); %; Real Names
+        legend(LabNames{legend_counter},'Location','eastoutside'); %; Real Names
         h = 4;                                  % height of plot in inches
-        w = 5;                                  % width of plot in inches
+        w = 6;                                  % width of plot in inches
         set(gcf, 'PaperSize', [w h]);           % set size of PDF page
         set(gcf, 'PaperPosition', [0 0 w h]);   % put plot in lower-left corner        
         fig_filename=fullfile(char([Script_Figs_dir, 'TGA_N2_PeakMLR_vs_Tpeak']));
@@ -224,7 +226,7 @@ min_T=300;  %initialize minimum temperature reported in TGA datataunt
 %     k=files{i,3};   % Find Lab Name
 %     L=files{i,4};   % Find Test Count
 %     m=files{i,2};   % Find Test Type
-%     if m>=24
+% if contains(filenames{i},"TGA")==1        % TGA Tests
 %     temp=min(EVAL_DATA{k,L,m}(:,2));
 %     if temp>min_T
 %         min_T=temp;
@@ -241,7 +243,7 @@ for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=24        % Just TGA Tests
+        if contains(filenames{i},"TGA")==1        % TGA Tests
         last = min(min(N_rows_all(k,:,m)-1,1021));
 
         max_T =max(EVAL_DATA{k,L,m}(:,2));
@@ -276,7 +278,7 @@ for i=1:N_files
             end
             shadedErrorBar(TGA_Temperature(1:last),TGA_dTdt(1:last,L+2,k,m),[2*TGA_dTdt(1:last,L+4,k,m) 2*TGA_dTdt(1:last,L+4,k,m)],'lineprops', {'k','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
 
-            if m==31 || m==32 || m==37  %higher heating rates, zoom out on the axes
+            if contains(filenames{i},["50K","100K"])==1        % TGA Testsm==31 || m==32 || m==37  %higher heating rates, zoom out on the axes
                 axis([300 800 0 100]);
             else
                 axis([300 800 0 25]);
@@ -302,13 +304,14 @@ close% Close figure
 
 %% All dT/dt curves at 10 K/min
 figure('Renderer', 'painters', 'Position', [100 100 650 350])
+box on 
 hold on
 i_legend=1;
 for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m==28 || m==33 || m==34 || m==36        % Just 10K/min TGA Tests
+    if contains(filenames{i},"TGA")==1 && contains(filenames{i},"10K")==1  % Just 10K/min TGA Tests
         if L==Test_count(m,k)    %If this dataset is the last one for this lab, do some statistics
             last = min(min(N_rows_all(k,:,m)-1,1021));
             legend_counter(i_legend)=k;
@@ -325,7 +328,7 @@ end
             xlabel('Temperature [K]');
             ylabel('Heating Rate, dT/dt  [K min^{-1}]');
 %             legend(QMJHL{legend_counter},'Location','northeastoutside'); %; QMJHL Names
-            legend(LabNames{legend_counter},'Location','northeastoutside'); %; Real Names
+            legend(LabNames{legend_counter},'Location','eastoutside' ,'FontSize', 7); %; Real Names
 
             h=3.25;                                  % height of plot in inches
             w=6;                                  % width of plot in inches
@@ -337,13 +340,14 @@ end
 close
         %% All dT/dt curves at 20 K/min
 figure('Renderer', 'painters', 'Position', [100 100 650 350])
+box on 
 hold on
 i_legend=1;
 for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m==30        % Just 10K/min TGA Tests
+    if contains(filenames{i},"TGA")==1 && contains(filenames{i},"20K")==1  % Just 20K/min TGA Tests
         if L==Test_count(m,k)    %If this dataset is the last one for this lab, do some statistics
             last = min(min(N_rows_all(k,:,m)-1,1021));
             legend_counter(i_legend)=k;
@@ -360,9 +364,9 @@ end
             xlabel('Temperature [K]');
             ylabel('Heating Rate, dT/dt  [K min^{-1}]');
 %             legend(QMJHL{legend_counter},'Location','northeastoutside');    % QMJHL Names
-            legend(LabNames{legend_counter},'Location','northeastoutside');    % Real Names
+            legend(LabNames{legend_counter},'Location','southeast');    % Real Names
             h=3.25;                                  % height of plot in inches
-            w=6;                                  % width of plot in inches
+            w=5;                                  % width of plot in inches
             set(gcf, 'PaperSize', [w h]);           % set size of PDF page
             set(gcf, 'PaperPosition', [0 0 w h]);   % put plot in lower-left corner
             fig_filename=fullfile(char([Script_Figs_dir, 'TGA_20K_dTdt']));
@@ -378,7 +382,7 @@ for i=1:N_files
     k=files{i,3};   % Find Lab Name
     L=files{i,4};   % Find Test Count
     m=files{i,2};   % Find Test Type
-    if m>=24        % Just TGA Tests
+    if contains(filenames{i},"TGA")==1  % Just TGA Tests
         last = min(min(N_rows_all(k,:,m)-1,1021));
 
         max_T =max(EVAL_DATA{k,L,m}(:,2));
@@ -403,7 +407,7 @@ for i=1:N_files
 
             for ix = 3:last-2 %1:last
 %             Calculate mean and stdeviation +/- 2 timesteps
-            if k==10     % TIFP TGA DATA: Tests 1 and 2 did not have a full N2 purge prior too measurement--> these should be plotted but not averaged (oxidation)
+            if contains(filenames{i},"TIFP")==1    % TIFP TGA DATA: Tests 1 and 2 did not have a full N2 purge prior too measurement--> these should be plotted but not averaged (oxidation)
                 TGA_MLR(ix,L+1,k,m)=nnz(TGA_MLR((ix-2:ix+2),(3:L),k,m));
                 TGA_MLR(ix,L+2,k,m)=mean_nonan(TGA_MLR((ix-2:ix+2),(3:L),k,m));
                 TGA_MLR(ix,L+3,k,m)=std_nonan(TGA_MLR((ix-2:ix+2),(3:L),k,m));
@@ -446,7 +450,7 @@ for i=1:N_files
             end
             shadedErrorBar(TGA_Temperature(1:last),TGA_MLR(1:last,L+2,k,m),[2*TGA_MLR(1:last,L+4,k,m) 2*TGA_MLR(1:last,L+4,k,m)],'lineprops', {'-k','LineWidth',1 }); %plot with shaded error bards = 2stdevmean
 
-            if m==30 || m==31 || m==32 || m==37  %higher heating rates, zoom out on the axes
+            if contains(filenames{i},["20K","50K","100K"])==1  %higher heating rates, zoom out on the axes
                 axis([300 800 0 inf]);
             else
                 axis([300 800 0 0.003]);
@@ -471,10 +475,10 @@ clear last
 close% Close figure
 
 %% Combine all of your TGA data from individual tests in N2 at 5K/min
-m=27;
-TGA_N2_5K_all=zeros(1021, Test_count(m,end)+4,2);
 col_old=0;
 i_legend=1;
+m=find(Test_types=="TGA_N2_5K");
+        TGA_N2_5K_all=zeros(1021, Test_count(m,end)+4,2);
 for k=1:N_Labs
     if Test_count(m,k)~=0
         col_new=Test_count(m,k);
@@ -508,6 +512,7 @@ end
 %plot Average m/m0 with shaded errorbars WITH individual data points from all tests
 figure('Renderer', 'painters', 'Position', [100 100 650 350])
 hold on
+box on
 for k=1:Test_count(m,end)
     plot(TGA_Temperature(:),TGA_N2_5K_all(:,k,1),'-','MarkerSize',2,'color',rgb(Colors{legend_counter(k)})) ;
 end
@@ -535,6 +540,7 @@ end
 %plot Average d(m/m0)/dt with shaded errorbars WITH individual data points from all tests
 figure('Renderer', 'painters', 'Position', [100 100 650 350])
 hold on
+box on
 for k=1:Test_count(m,end)
     plot(TGA_Temperature(:),TGA_N2_5K_all(:,k,2),'-','MarkerSize',2,'color',rgb(Colors{legend_counter(k)})) ;
 end
@@ -557,13 +563,12 @@ end
             fig_filename=fullfile(char([Script_Figs_dir, Test_types{m} '_dmdt_w_avg']));
             print(fig_filename,'-dpdf')
 
-
 clear m legend_counter fig_filename
 close all
 
 %% Combine all of your TGA data from individual tests in N2 at 10K/min (ALSO 10K/min in Argon)
-m=28;
-Test_count_10K=Test_count(28,end)+Test_count(36,end);       %N2 + Argon
+Test_count_10K=Test_count(find(Test_types=="TGA_N2_10K"),end)+Test_count(find(Test_types=="TGA_Ar_10K"),end);       %N2 + Argon()
+m=find(Test_types=="TGA_N2_10K");
 TGA_N2_10K_all=zeros(1021, Test_count_10K+4,2);
 col_old=0;
 i_legend=1;
@@ -577,7 +582,8 @@ for k=1:N_Labs
         i_legend=i_legend+Test_count(m,k);
     end
 end
-m=36;       % Include (10K/min in Argon)
+
+m = find(Test_types=="TGA_Ar_10K");
 for k=1:N_Labs
     if Test_count(m,k)~=0
         col_new=Test_count(m,k);
@@ -595,9 +601,22 @@ TGA_N2_10K_all(TGA_N2_10K_all==0)=NaN;
 % Do some Statistics now that you have all of your data together
 %Calculate mean and stdeviation +/- 0 timesteps
 
-%NOTE: For these statistics [LCPP(wayyy too high), UDRI (30K temp shift),
-%TIFP (two peaks)] data is clesarly incorrect, so it will not be used for
-%statistics. Hence the indexing: [1:4 8:12  15:21 23:Test_countTest_count].
+%NOTE: Some datasets have been neglected when calculating these statistics...
+% because they have been identified as outliers [LCPP(dT/dt is too high), UDRI (20K temp shift), TIFP (two peaks), Ulster (50K-60K temp shift)] 
+% Hence the special indexing: [1:4 8:12  15:21 23:Test_count]. 
+%Feb. 24, 2023 - identify this indexing issue, create short loop and [TGA_N2_10K_indexing] to address it but solution remains incomplete, keep previous indexing for now  
+m=find(Test_types=="TGA_N2_10K");
+temp_counter=0;
+for k=1:N_Labs
+    if contains(LabNames(k),["LCPP" "TIFP" "UDRI" "ULSTER"])==0
+%         temp_counter=temp_counter+1;
+        TGA_N2_10K_indexing(1,k)=Test_count(m,k);
+    elseif contains(LabNames(k),["LCPP" "TIFP" "UDRI" "ULSTER"])==1
+        TGA_N2_10K_indexing(2,k)=Test_count(m,k);
+    end
+end
+clear temp_counter m
+
 for ix=1:1021
     TGA_N2_10K_all(ix,(Test_count_10K+1),1)=nnz(TGA_N2_10K_all((ix-0:ix+0),[1:4 8:12  15:21 23:Test_count_10K],1));          % Count, N
     TGA_N2_10K_all(ix,(Test_count_10K+2),1)=mean_nonan(TGA_N2_10K_all((ix-0:ix+0),[1:4 8:12  15:21 23:Test_count_10K],1));        % mean
@@ -610,7 +629,7 @@ for ix=1:1021
     TGA_N2_10K_all(ix,(Test_count_10K+4),2)=TGA_N2_10K_all(ix,(Test_count_10K+3),2)/sqrt(TGA_N2_10K_all(ix,Test_count_10K+1,2));  % stdev mean
 end
 
-m=28;
+m=find(Test_types=="TGA_N2_10K");
 %plot Average m/m0 with shaded errorbars WITH individual data points from all tests
 figure('Renderer', 'painters', 'Position', [100 100 800 450])
 hold on
@@ -665,7 +684,7 @@ clear m legend_counter
 close all
 
 %% Combine all of your TGA data from individual tests in N2 at 20K/min
-m=30;
+m=find(Test_types=="TGA_N2_20K");
 TGA_N2_20K_all=zeros(1021, Test_count(m,end)+4,2);
 col_old=0;
 i_legend=1;
@@ -754,7 +773,7 @@ end
 clear m legend_counter fig_filename
 close all
 %% Combine all of your TGA data from individual tests in N2/21%O2 at 10K/min
-m=34;
+m=find(Test_types=="TGA_O2-21_10K");
 TGA_N2_O2_21_10K_all=zeros(1021, Test_count(m,end)+4,2);
 col_old=0;
 i_legend=1;
@@ -776,9 +795,6 @@ TGA_N2_O2_21_10K_all(TGA_N2_O2_21_10K_all==0)=NaN;
 % Do some Statistics now that you have all of your data together
 %Calculate mean and stdeviation +/- 0 timesteps
 
-%NOTE: For these statistics [LCPP(wayyy too high), UDRI (30K temp shift),
-%TIFP (two peaks)] data is clesarly incorrect, so it will not be used for
-%statistics. Hence the indexing: [1:4 8  11 15:Test_count].
 for ix=1:1021
     TGA_N2_O2_21_10K_all(ix,(Test_count(m,end)+1),1)=nnz(TGA_N2_O2_21_10K_all((ix-0:ix+0),[1:Test_count(m,end)],1));          % Count, N
     TGA_N2_O2_21_10K_all(ix,(Test_count(m,end)+2),1)=mean_nonan(TGA_N2_O2_21_10K_all((ix-0:ix+0),[1:Test_count(m,end)],1));        % mean


### PR DESCRIPTION
This is a first update to our scripts to provide flexibility in how data can be read in. This allows us to move away from fixed indexing (i,j,k = 1,2,3) to identifying and analyzing datasets based on metadata (e.g., Test_type = "TGA" or heating rate ="10K"). 

This is a work in progress - further edits will be made, as possible, to increase the resilience of these processing scripts.