### PR TITLE
Update to TGA_analysis.py

### DIFF
--- a/Scripts/MaCFP-4/DSC_analysis.py
+++ b/Scripts/MaCFP-4/DSC_analysis.py
@@ -408,6 +408,107 @@ for path in TMDSC:
     fig1.savefig(str(base_dir) + '/DSC/TM-DSC.{}'.format(ex))
     plt.close(fig1)
 
+# ------------------------------------
+# region individual DSC plots
+# ------------------------------------
+
+Individual_dir = base_dir / 'DSC' / 'Individual'
+Individual_dir.mkdir(parents=True, exist_ok=True)
+
+for path in DSC_Data:
+    df_raw = pd.read_csv(path)
+    if 'Heat Flow Rate (W/g)' not in df_raw.columns or not np.isfinite(df_raw['Heat Flow Rate (W/g)']).any():
+        continue
+    stem = path.stem
+    parts = stem.split('_')
+
+    institution = parts[0]
+    material = 'Wood' if 'Wood' in parts else 'Unknown'
+    device = 'STA' if 'STA' in parts else 'DSC'
+
+    if 'N2' in parts:
+        atmosphere = 'N2'
+    else:
+        atmosphere = next((part for part in parts if part.startswith('O2-')), 'Unknown')
+
+    heating_rate = next((part for part in parts if re.fullmatch(r'\d+K', part)), 'Unknown')
+    repetition = next((part for part in parts if re.fullmatch(r'[Rr]\d+', part)), 'Unknown').upper()
+
+    label, color = label_def(institution)
+
+    fig, ax = plt.subplots(figsize=(6, 4))
+
+    if device == 'STA':
+        df = Integral_DSC(df_raw)
+        ax.plot(df['Temperature (K)'], df['Heat Flow Rate (W/g)'], color=color, label=label)
+
+        df['Normalized mass'] = df['Mass (mg)'] / np.mean(df['Mass (mg)'].iloc[0:5])
+        dt = df['Time (s)'].shift(-1) - df['Time (s)'].shift(1)
+        df['dm/dt unfiltered'] = (df['Normalized mass'].shift(1) - df['Normalized mass'].shift(-1)) / dt
+        df['dm/dt unfiltered'] = df['dm/dt unfiltered'].interpolate(method='linear', limit_direction='both')
+        df['dm/dt'] = savgol_filter(df['dm/dt unfiltered'], 41, 3)
+
+        peak_MLR = df['dm/dt'].max()
+        peak_idx = df['dm/dt'].idxmax()
+        threshold = 0.1 * peak_MLR
+
+        before_peak = df.loc[:peak_idx]
+        idx1 = before_peak[before_peak['dm/dt'] < threshold].index[-1] + 1
+
+        after_peak = df.loc[peak_idx:]
+        idx2 = after_peak[after_peak['dm/dt'] <= threshold].index[0]
+
+        T2 = df.loc[idx2, 'Temperature (K)']
+        HF2 = df.loc[idx2, 'Heat Flow Rate (W/g)']
+
+        while idx1 < peak_idx:
+            T1_test = df.loc[idx1, 'Temperature (K)']
+            HF1_test = df.loc[idx1, 'Heat Flow Rate (W/g)']
+            df_left = df.loc[idx1:peak_idx]
+            baseline_left = np.interp(df_left['Temperature (K)'], [T1_test, T2], [HF1_test, HF2])
+
+            if np.all(df_left['Heat Flow Rate (W/g)'].to_numpy() >= baseline_left - 1e-9):
+                break
+
+            idx1 += 1
+
+        T1 = df.loc[idx1, 'Temperature (K)']
+        Tpeak = df.loc[peak_idx, 'Temperature (K)']
+        T2 = df.loc[idx2, 'Temperature (K)']
+
+        HF1 = df.loc[idx1, 'Heat Flow Rate (W/g)']
+        HFpeak = df.loc[peak_idx, 'Heat Flow Rate (W/g)']
+        HF2 = df.loc[idx2, 'Heat Flow Rate (W/g)']
+
+        M1 = df.loc[idx1, 'Normalized mass']
+        M2 = df.loc[idx2, 'Normalized mass']
+        mass_loss = M1 - M2
+        mass_loss_percent = 100 * mass_loss
+
+        df_subset = df.loc[idx1:idx2].copy()
+        df_subset['baseline'] = np.interp(df_subset['Temperature (K)'], [T1, T2], [HF1, HF2])
+        df_subset['HF_corrected'] = df_subset['Heat Flow Rate (W/g)'] - df_subset['baseline']
+
+        integrated_heat = np.trapezoid(df_subset['HF_corrected'], df_subset['Time (s)'])
+        heat_of_reaction = integrated_heat / mass_loss
+
+        ax.scatter([T1, Tpeak, T2], [HF1, HFpeak, HF2], color='black', s=30, zorder=5)
+        ax.plot([T1, T2], [HF1, HF2], color=color, linewidth=0.8, zorder=4)
+        ax.fill_between(df_subset['Temperature (K)'], df_subset['Heat Flow Rate (W/g)'], df_subset['baseline'], facecolor='none', edgecolor='black', hatch='////', linewidth=0, zorder=2)
+
+        ax.text(0.97, 0.95, f'Integrated heat: {integrated_heat:.0f} J/g\nCorresponding mass loss: {mass_loss_percent:.1f}%\nHeat of reaction: {heat_of_reaction:.0f} J/g', transform=ax.transAxes, ha='right', va='top', fontsize=9, bbox=dict(facecolor='white', edgecolor='none', alpha=0.7))
+
+    else:
+        ax.plot(df_raw['Temperature (K)'], df_raw['Heat Flow Rate (W/g)'], color=color, label=label)
+
+    ax.set_xlabel('Temperature [K]')
+    ax.set_ylabel('Heat flow [W g$^{-1}$]')
+    ax.legend(loc='best')
+    fig.tight_layout()
+
+    filename = f'{institution}_{material}_{device}_{atmosphere}_{heating_rate}_{repetition}'
+    fig.savefig(Individual_dir / f'{filename}.{ex}')
+    plt.close(fig)
 
 
 #------------------------------------
@@ -422,13 +523,13 @@ results = []
 for exp in STA_Data:
     df_raw = pd.read_csv(exp)
     df = Integral_DSC(df_raw)
-    
+
     df['Normalized mass'] = df['Mass (mg)'] / np.mean(df['Mass (mg)'].iloc[0:5])
     dt = df['Time (s)'].shift(-1) - df['Time (s)'].shift(1)
     df['dm/dt unfiltered'] = (df['Normalized mass'].shift(1) - df['Normalized mass'].shift(-1)) / dt
     df['dm/dt unfiltered'] = df['dm/dt unfiltered'].interpolate(method='linear', limit_direction='both') #avoid nan_values
     df['dm/dt'] = savgol_filter(df['dm/dt unfiltered'],41,3)
-    
+
     # Find peak MLR and its index
     peak_MLR = df['dm/dt'].max()
     peak_idx = df['dm/dt'].idxmax()
@@ -436,33 +537,56 @@ for exp in STA_Data:
     # Find threshold (10% of peak) and indices
     threshold = 0.1 * peak_MLR
     before_peak = df.loc[:peak_idx]
-    idx1 = before_peak[(before_peak['dm/dt'] >= threshold) & (before_peak.index > 10)].index[0]
+    idx1 = before_peak[before_peak['dm/dt'] < threshold].index[-1] + 1
 
     after_peak = df.loc[peak_idx:]
     idx2 = after_peak[after_peak['dm/dt'] <= threshold].index[0]
-    
+
+    # -----------------------------------------------------------------
+    # Shift left integration point until the baseline stays below the DSC
+    # -----------------------------------------------------------------
+    T2 = df.loc[idx2, 'Temperature (K)']
+    HF2 = df.loc[idx2, 'Heat Flow Rate (W/g)']
+
+    while idx1 < peak_idx:
+        T1_test = df.loc[idx1, 'Temperature (K)']
+        HF1_test = df.loc[idx1, 'Heat Flow Rate (W/g)']
+
+        df_left = df.loc[idx1:peak_idx]
+        baseline_left = np.interp(
+            df_left['Temperature (K)'],
+            [T1_test, T2],
+            [HF1_test, HF2]
+        )
+
+        if np.all(df_left['Heat Flow Rate (W/g)'].to_numpy() >= baseline_left - 1e-9):
+            break
+
+        idx1 += 1
+
     # Extract data for integration
     T1 = df.loc[idx1, 'Temperature (K)']
     T2 = df.loc[idx2, 'Temperature (K)']
     HF1 = df.loc[idx1, 'Heat Flow Rate (W/g)']
     HF2 = df.loc[idx2, 'Heat Flow Rate (W/g)']
-    M1= df.loc[idx1, 'Normalized mass']
-    M2= df.loc[idx2, 'Normalized mass']
+    M1 = df.loc[idx1, 'Normalized mass']
+    M2 = df.loc[idx2, 'Normalized mass']
+
     # Subset data between the two indices
     df_subset = df.loc[idx1:idx2].copy()
-    
+
     # Create linear baseline
     df_subset['baseline'] = np.interp(
-        df_subset['Temperature (K)'], 
-        [T1, T2], 
+        df_subset['Temperature (K)'],
+        [T1, T2],
         [HF1, HF2]
     )
-    
+
     # Subtract baseline from heat flow rate
     df_subset['HF_corrected'] = df_subset['Heat Flow Rate (W/g)'] - df_subset['baseline']
-    
+
     # Integrate corrected heat flow rate with respect to time
-    value = np.trapezoid(df_subset['HF_corrected'], df_subset['Time (s)'])/(df['Normalized mass'][idx1]- df['Normalized mass'][idx2])
+    value = np.trapezoid(df_subset['HF_corrected'], df_subset['Time (s)']) / (M1 - M2)
 
     # Store results
     results.append({
@@ -517,3 +641,5 @@ with open(str(base_dir) + '/DSC/heat_of_reaction_table.tex', 'w') as f:
     f.write(latex_table)
 
 print(final_table)
+# print('DSC files:', sum('_DSC' in p.stem for p in DSC_Data))
+# print('STA files:', sum('STA' in p.stem for p in DSC_Data))

--- a/Scripts/MaCFP-4/TGA_analysis.py
+++ b/Scripts/MaCFP-4/TGA_analysis.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from scipy.signal import savgol_filter
 from fnmatch import fnmatch
 from typing import Optional, Union, List, Dict
+from matplotlib.patches import Ellipse
 
 from Utils import device_data, get_series_names, make_institution_table, device_subset, label_def, interpolation, format_latex
 from Utils import format_with_uncertainty, format_temperature, format_regular, extract_heating_rate, extract_atmosphere, get_condition_key
@@ -329,11 +330,11 @@ for HR in unique_HR:
         by_label = dict(zip(labels, handles))
         current_ax.legend(by_label.values(), by_label.keys(), ncol=math.ceil(len(by_label)/6))
 
-    ax.text(0.97, 0.05, f'N$_{2}$,$\,${HR[:-1]} K/min', transform=ax.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
+    ax.text(0.97, 0.05, f'N$_{2}$,$\\,${HR[:-1]} K/min', transform=ax.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
 
     ax_ranges.axvspan(348, 398, color='deepskyblue', alpha=0.20, zorder=0)
     ax_ranges.axvspan(500, 800, color='orange', alpha=0.15, zorder=0)
-    ax_ranges.text(0.97, 0.05, f'N$_{2}$,$\,${HR[:-1]} K/min', transform=ax_ranges.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
+    ax_ranges.text(0.97, 0.05, f'N$_{2}$,$\\,${HR[:-1]} K/min', transform=ax_ranges.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
 
     fig.tight_layout()
     fig_ranges.tight_layout()
@@ -356,6 +357,14 @@ plot_configs = [
 for series in unique_conditions_material:
     parts = series.split('_')
     material, dev, atm, hr  = parts[:4]
+    if atm == 'N2':
+        atmosphere_label = 'N$_2$'
+    elif atm == 'O2-20':
+        atmosphere_label = '20% O$_2$'
+    elif atm == 'O2-21':
+        atmosphere_label = '21% O$_2$'
+    else:
+        atmosphere_label = atm
     TGA_subset_paths = [p for p in TGA_Data if f"{material}_" in p.name and f"_{atm}_{hr}_" in p.name]
     if atm == 'O2-21':
         TGA_subset_paths += [p for p in TGA_Data if f"{material}_" in p.name and f"_O2-20_{hr}_" in p.name]
@@ -390,17 +399,23 @@ for series in unique_conditions_material:
         handles1, labels1 = ax1.get_legend_handles_labels()
         by_label1 = dict(zip(labels1, handles1))
 
-        if hr == '10K':
-            ax1.legend(by_label1.values(), by_label1.keys(),
-                       fontsize=8,
-                       loc='lower left')
+        if config['suffix'] == '_zoom2':
+            if hr == '10K':
+                ax1.legend(by_label1.values(), by_label1.keys(), fontsize=8, loc='upper left', ncol=3, columnspacing=0.9)
+            else:
+                ax1.legend(by_label1.values(), by_label1.keys(), loc='upper left', ncol=3, columnspacing=0.9)
+        elif config['suffix'] == '_zoom1' and hr == '10K':
+            ax1.legend(by_label1.values(), by_label1.keys(), fontsize=8, loc='upper left', ncol=3, columnspacing=0.9)
+        elif config['suffix'] == '_zoom1':
+            ax1.legend(by_label1.values(), by_label1.keys(), loc='lower left', ncol=2)
         else:
-            ax1.legend(by_label1.values(), by_label1.keys())
-        if hr == '10K':
-            ax1.legend(by_label1.values(), by_label1.keys(), fontsize=8, loc='lower left')
-        else:
-            ax1.legend(by_label1.values(), by_label1.keys())
+            if hr == '10K':
+                ax1.legend(by_label1.values(), by_label1.keys(), fontsize=8, loc='lower left')
+            else:
+                ax1.legend(by_label1.values(), by_label1.keys(), loc='lower left')
 
+        ax1.text(0.97, 0.95, f'{atmosphere_label},$\\,${hr[:-1]} K/min', transform=ax1.transAxes, ha='right', va='top',
+                 fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
         ax2.set_ylim(bottom=config['ylim2'][0], top=config['ylim2'][1])
         ax2.set_xlim(left=config['xlim'][0], right=config['xlim'][1])
         ax2.set_xlabel('Temperature [K]')
@@ -408,7 +423,14 @@ for series in unique_conditions_material:
         fig2.tight_layout()
         handles2, labels2 = ax2.get_legend_handles_labels()
         by_label2 = dict(zip(labels2, handles2))
-        ax2.legend(by_label2.values(), by_label2.keys())
+
+        if hr == '10K':
+            ax2.legend(by_label2.values(), by_label2.keys(), fontsize=8, loc='upper right')
+        else:
+            ax2.legend(by_label2.values(), by_label2.keys(), loc='upper right')
+
+        ax2.text(0.03, 0.95, f'{atmosphere_label},$\\,${hr[:-1]} K/min', transform=ax2.transAxes, ha='left', va='top',
+                 fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
 
         ax3.set_ylim(bottom=config['ylim1'][0], top=config['ylim1'][1])
         ax3.set_xlim(left=config['xlim'][0], right=config['xlim'][1])
@@ -419,14 +441,74 @@ for series in unique_conditions_material:
         handles3, labels3 = ax3.get_legend_handles_labels()
         by_label3 = dict(zip(labels3, handles3))
 
-        if hr == '10K':
-            ax3.legend(by_label3.values(), by_label3.keys(), fontsize=8, loc='lower left')
+        if config['suffix'] == '_zoom2':
+            if hr == '10K':
+                ax3.legend(by_label3.values(), by_label3.keys(), fontsize=8, loc='upper left', ncol=3, columnspacing=0.9)
+            else:
+                ax3.legend(by_label3.values(), by_label3.keys(), loc='upper left', ncol=3, columnspacing=0.9)
+        elif config['suffix'] == '_zoom1':
+            if hr == '10K':
+                ax3.legend(by_label3.values(), by_label3.keys(), fontsize=8, loc='lower left', ncol=2)
+            else:
+                ax3.legend(by_label3.values(), by_label3.keys(), loc='lower left', ncol=2)
         else:
-            ax3.legend(by_label3.values(), by_label3.keys())
+            if hr == '10K':
+                ax3.legend(by_label3.values(), by_label3.keys(), fontsize=8, loc='lower left')
+            else:
+                ax3.legend(by_label3.values(), by_label3.keys(), loc='lower left')
+
+        ax3.text(0.97, 0.95, f'{atmosphere_label},$\\,${hr[:-1]} K/min', transform=ax3.transAxes, ha='right', va='top',
+                 fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
 
         fig1.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass{config["suffix"]}.{ex}')
+
+        if material == 'Wood' and atm == 'N2' and hr == '10K' and config['suffix'] == '':
+
+            # BEFORE
+            before_ellipse = Ellipse((410, 0.97), width=250, height=0.14, fill=False, edgecolor='black', linewidth=2.0,
+                                     zorder=10)
+            ax1.add_patch(before_ellipse)
+            before_text = ax1.text(0.55, 0.95, 'before', transform=ax1.transAxes, ha='right', va='top', fontsize=14)
+
+            fig1.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass_before.{ex}')
+
+            before_ellipse.remove()
+            before_text.remove()
+
+            # MARKED REGIONS
+            black_ellipse = Ellipse((340, 0.97), width=160, height=0.14, fill=False, edgecolor='black', linewidth=2.0,
+                                    zorder=10)
+            blue_ellipse = Ellipse((660, 0.26), width=65, height=0.32, fill=False, edgecolor='dodgerblue',
+                                   linewidth=2.0, zorder=10)
+            red_ellipse = Ellipse((950, 0.13), width=65, height=0.26, fill=False, edgecolor='red', linewidth=2.0,
+                                  zorder=10)
+
+            ax1.add_patch(black_ellipse)
+            ax1.add_patch(blue_ellipse)
+            ax1.add_patch(red_ellipse)
+
+            fig1.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass_marked_regions.{ex}')
+
+            # AFTER
+            after_ellipse = Ellipse((410, 1.02), width=250, height=0.17, fill=False, edgecolor='black', linewidth=2.0,
+                                    zorder=10)
+            ax3.add_patch(after_ellipse)
+
+            after_text = ax3.text(0.55, 0.95, 'after', transform=ax3.transAxes, ha='right', va='top', fontsize=14)
+
+            fig3.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass_400Knorm_after.{ex}')
+
+            after_ellipse.remove()
+            after_text.remove()
+
+        elif material == 'Wood' and atm == 'N2' and hr == '10K' and config['suffix'] == '_zoom1':
+            ax1.axvline(400, color='black', linestyle=':', linewidth=2, zorder=10)
+
+            fig1.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass_zoom1_marked.{ex}')
+
         fig2.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_dmdt{config["suffix"]}.{ex}')
         fig3.savefig(f'{base_dir}/TGA/TGA_{material}_{atm}_{hr}_Mass_400Knorm{config["suffix"]}.{ex}')
+
         plt.close(fig1)
         plt.close(fig2)
         plt.close(fig3)

--- a/Scripts/MaCFP-4/TGA_analysis.py
+++ b/Scripts/MaCFP-4/TGA_analysis.py
@@ -566,12 +566,12 @@ for path in TGA_Data:
 
 
 # Average plot for Mass and mass loss rate per unique condition (averaging over different institutes)
-color = {'5K':'blue','10K':'black','20K':'red'}
+color = {'2K':'green','5K':'blue','10K':'black','20K':'red'}
 fig1, ax1 = plt.subplots(figsize=(6, 4))
 fig2, ax2 = plt.subplots(figsize=(6, 4))
 average_data = {}
 
-for series in ['Wood_*_N2_5K','Wood_*_N2_10K','Wood_*_N2_20K']:
+for series in ['Wood_*_N2_2K','Wood_*_N2_5K','Wood_*_N2_10K','Wood_*_N2_20K']:
     parts = series.split('_')
     atm, hr  = parts[2:]
     for subset in [item for item in TGA_sets if fnmatch(item, f'*{series}')]:
@@ -581,7 +581,10 @@ for series in ['Wood_*_N2_5K','Wood_*_N2_10K','Wood_*_N2_20K']:
             df = Calculate_dm_dt(df)
             ax1.plot(df['Temperature (K)'], df['Normalized mass'], '-', color = color[hr], alpha=0.1, linewidth = 0.1, zorder=4)
             ax2.plot(df['Temperature (K)'], df['dm/dt'], '-', color = color[hr], alpha=0.15, linewidth = 0.1, zorder=4)
-    df_average = average_tga_series(series,['UAI','IMT'],temp_filter={'FPL': 400,'UCantabria': 380})
+    if hr == '2K':
+        df_average = average_tga_series(series, ['UAI'], temp_filter={'FPL': 400, 'UCantabria': 380})
+    else:
+        df_average = average_tga_series(series, ['UAI', 'IMT'], temp_filter={'FPL': 400, 'UCantabria': 380})
     average_data['Wood_'+ atm +'_' + hr] = df_average[['Temperature (K)', 'MLR (1/s)']].copy()
     ax1.plot(df_average['Temperature (K)'], df_average['Normalized Mass'], label = hr + '/min', color = color[hr], zorder = 3)
     ax1.fill_between(df_average['Temperature (K)'], 

--- a/Scripts/MaCFP-4/TGA_analysis.py
+++ b/Scripts/MaCFP-4/TGA_analysis.py
@@ -309,24 +309,41 @@ unique_HR = {s.split('_')[4] for s in TGA_sets}
 for HR in unique_HR:
     if 'iso' in HR:
         continue
-    else:
-        fig, ax = plt.subplots(figsize=(6, 4))
-        TGA_sub_set = device_subset(TGA_sets, HR, 'N2') + device_subset(TGA_sets, HR, 'O2-21') + device_subset(TGA_sets, HR, 'O2-20')
-        for set in TGA_sub_set:
-            average = average_HR_tga_series(set)
-            label, color = label_def(set.split('_')[0])
-            ax.plot(average['Temperature (K)'], average['dTdt (K/min)'], '-', label = label, color=color)
-            ax.set_xlabel('Temperature [K]')
-            ax.set_ylabel('Heating Rate dT/dt [K min$^{-1}$]')
-            ax.set_title('dT/dt in TGA tests at {} K/min'.format(HR[:-1]))
-            fig.tight_layout()
-            handles, labels = ax.get_legend_handles_labels()
-            by_label = dict(zip(labels, handles))
-            ax.legend(by_label.values(), by_label.keys(), ncol=math.ceil(len(by_label) / 6))
-            ax.set_xlim(right=1100)
-        plt.savefig(str(base_dir) +'/TGA/dTdt_TGA_{}Kmin.{}'.format(HR[:-1], ex))
-        plt.close(fig)
 
+    fig, ax = plt.subplots(figsize=(6, 4))
+    fig_ranges, ax_ranges = plt.subplots(figsize=(6, 4))
+    TGA_sub_set = device_subset(TGA_sets, HR, 'N2') + device_subset(TGA_sets, HR, 'O2-21') + device_subset(TGA_sets, HR, 'O2-20')
+
+    for set in TGA_sub_set:
+        average = average_HR_tga_series(set)
+        label, color = label_def(set.split('_')[0])
+
+        ax.plot(average['Temperature (K)'], average['dTdt (K/min)'], '-', label=label, color=color)
+        ax_ranges.plot(average['Temperature (K)'], average['dTdt (K/min)'], '-', label=label, color=color)
+
+    for current_ax in [ax, ax_ranges]:
+        current_ax.set_xlabel('Temperature [K]')
+        current_ax.set_ylabel('Heating Rate dT/dt [K min$^{-1}$]')
+        current_ax.set_xlim(right=1100)
+        handles, labels = current_ax.get_legend_handles_labels()
+        by_label = dict(zip(labels, handles))
+        current_ax.legend(by_label.values(), by_label.keys(), ncol=math.ceil(len(by_label)/6))
+
+    ax.text(0.97, 0.05, f'N$_{2}$,$\,${HR[:-1]} K/min', transform=ax.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
+
+    ax_ranges.axvspan(348, 398, color='deepskyblue', alpha=0.20, zorder=0)
+    ax_ranges.axvspan(500, 800, color='orange', alpha=0.15, zorder=0)
+    ax_ranges.text(0.97, 0.05, f'N$_{2}$,$\,${HR[:-1]} K/min', transform=ax_ranges.transAxes, ha='right', va='bottom', fontsize=11, bbox=dict(facecolor='white', edgecolor='none', alpha=0.35))
+
+    fig.tight_layout()
+    fig_ranges.tight_layout()
+
+    fig.savefig(str(base_dir) + '/TGA/dTdt_TGA_{}Kmin.{}'.format(HR[:-1], ex))
+    fig_ranges.savefig(str(base_dir) + '/TGA/dTdt_TGA_{}Kmin_ranges.{}'.format(HR[:-1], ex))
+
+    plt.close(fig)
+    plt.close(fig_ranges)
+#--------------------------------------------------------
 
 
 # Mass and mass loss rate plots for all unique atmospheres and heating rates 
@@ -413,8 +430,7 @@ for series in unique_conditions_material:
         plt.close(fig1)
         plt.close(fig2)
         plt.close(fig3)
-
-
+#--------------------------------------------------------
 
 
 
@@ -463,8 +479,7 @@ for path in TGA_Data:
     fig.tight_layout()
     fig.savefig(str(base_dir) + f'/TGA/Individual/{path.stem}.{ex}')
     plt.close(fig)
-
-
+#--------------------------------------------------------
 
 
 

--- a/Scripts/MaCFP-4/TGA_analysis.py
+++ b/Scripts/MaCFP-4/TGA_analysis.py
@@ -868,3 +868,42 @@ latex_string_400Knorm = latex_string_400Knorm.replace('m/m_{400K} at 950~K (\\%)
 
 with open(str(base_dir) + f'/TGA/TGA_Values_400Knorm.tex', 'w') as f:
     f.write(latex_string_400Knorm)
+
+
+# =============================================================================
+# Comparison of MaCFP4 and MaCFP2 TGA repeatability and reproducibility
+# =============================================================================
+
+tga_comparison_latex = r'''
+\begin{table}[ht]
+\centering
+\caption{Comparison of MaCFP4 and MaCFP2 TGA repeatability and reproducibility.}
+\label{tab:tga_macfp2_comparison}
+\begin{tabular}{|c|c|c|}
+\hline
+ & \textbf{MaCFP4} & \textcolor{red}{\textbf{MaCFP2}} \\
+\hline
+\multirow{4}{*}{\shortstack{Intralab\\min--max\\repeatability}}
+& \multicolumn{2}{c|}{\textbf{Peak temperature difference}} \\
+\cline{2-3}
+& $\sim 5$ K & \textcolor{red}{$\sim 5$ K} \\
+\cline{2-3}
+& \multicolumn{2}{c|}{\textbf{Peak MLR}} \\
+\cline{2-3}
+& $\sim 0.0002$ s$^{-1}$ ($<15\,\%$) & \textcolor{red}{$\sim 0.0002$ s$^{-1}$ ($<10\,\%$)} \\
+\hline
+\multirow{4}{*}{\shortstack{Interlab\\min--max\\reproducibility}}
+& \multicolumn{2}{c|}{\textbf{Peak temperature difference}} \\
+\cline{2-3}
+& $\sim 10$ K (excl.\ outlier) & \textcolor{red}{$\sim 15$ K (excl.\ outlier)} \\
+\cline{2-3}
+& \multicolumn{2}{c|}{\textbf{Peak MLR}} \\
+\cline{2-3}
+& $\sim 0.0004$ s$^{-1}$ ($30\,\%$) & \textcolor{red}{$\sim 0.0005$ s$^{-1}$ ($20\,\%$)} \\
+\hline
+\end{tabular}
+\end{table}
+'''
+
+with open(str(base_dir) + '/TGA/TGA_MaCFP2_Comparison.tex', 'w') as f:
+    f.write(tga_comparison_latex)


### PR DESCRIPTION
Details provided in the individual commit descriptions.

@KarenDeLannoye could you please check the TGA datasets that are manually excluded in `TGA_analysis.py`? I believe there was a reason for excluding them previously, but I'm not sure whether that still applies.

Thank you in advance!

**EDIT**: I have also added changes to `DSC_analysis.py`, This might also be of interest to @leventon and @luciehasalova.

- There was an issue with the way the integration limits for the heat of reaction calculation were determined.
- To make the calculation transparent, I added individual plots for every measurement, showing the integrated region. This makes it easy to verify the origin of each reported heat of reaction value.
- For some measurements, the integration region looked like this:
<img width="1800" height="1200" alt="CERIB_Wood_STA_N2_5K_R1" src="https://github.com/user-attachments/assets/5cc63cc0-bad9-4585-8884-70ce5e35800d" />

- I first modified the search algorithm so that the integration limits are determined starting from the main peak and moving towards both sides: 
<img width="1800" height="1200" alt="CERIB_Wood_STA_N2_5K_R1" src="https://github.com/user-attachments/assets/a5c7394d-9659-4cc1-8b4e-f7dd5b3d4e7b" />

- This significantly improved the results, but in some cases small inconsistencies like the following still occurred:
<img width="1800" height="1200" alt="BUWfd_Wood_STA_N2_50K_R1" src="https://github.com/user-attachments/assets/95baffb1-f979-41a2-a737-6bd5dec20eba" />

- Therefore, I introduced an additional iterative adjustment of the left integration point. The point is shifted slightly towards the peak until the linear baseline no longer crosses the DSC curve. The resulting integration region is now consistent for all datasets:
<img width="1800" height="1200" alt="BUWfd_Wood_STA_N2_50K_R1" src="https://github.com/user-attachments/assets/2a2c0ddb-1ba8-4ede-8f53-7976d7e7fccc" />

- Looking ahead, I think we should explicitly ask contributors (in the README) to specify whether the baseline originating from the empty-pan measurement has already been subtracted from their DSC data. Ideally, contributors would also upload the corresponding baseline measurement. We could then perform the subtraction during post-processing, giving us much better control over the data. In addition, we currently assume that the uploaded DSC signal is normalized by the initial sample mass. This is the standard convention, but contributors should explicitly verify and confirm that this is indeed the case. It is worth noting that, with this convention, the DSC signal remains normalized by the initial mass even after part of the sample (e.g. moisture) has already been lost.
- We also implicitly assume that all measurements are performed in STA mode. If only conventional DSC measurements are available (which can actually provide higher-quality DSC data), the corresponding mass-loss information is missing and the current heat-of-reaction calculations cannot be performed. I expect we will address this once someone uploads a dataset containing DSC-only measurements :-)

My apologies for the long message, but at least everything is now documented here for future reference.

Vojtěch